### PR TITLE
Avoid app crash when trying to use flash with incompatible camera

### DIFF
--- a/android/src/main/java/com/ahm/capacitor/camera/preview/CameraPreview.java
+++ b/android/src/main/java/com/ahm/capacitor/camera/preview/CameraPreview.java
@@ -198,7 +198,7 @@ public class CameraPreview extends Plugin implements CameraActivity.CameraPrevie
 
         List<String> supportedFlashModes;
         supportedFlashModes = camera.getParameters().getSupportedFlashModes();
-        if (supportedFlashModes.indexOf(flashMode) > -1) {
+        if (supportedFlashModes != null && supportedFlashModes.indexOf(flashMode) > -1) {
             params.setFlashMode(flashMode);
         } else {
             call.reject("Flash mode not recognised: " + flashMode);


### PR DESCRIPTION
On Android, when you try to use flash with an incompatible camera (front camera), it makes the app to crash.
This PR just avoid the app to crash.