### PR TITLE
fix: Stopping of camera preview & more cleanup

### DIFF
--- a/ios/Plugin/CameraController.swift
+++ b/ios/Plugin/CameraController.swift
@@ -428,7 +428,32 @@ extension CameraController {
         } catch {
             throw CameraControllerError.invalidOperation
         }
+    }
 
+    func cleanup() {
+        if let captureSession = self.captureSession {
+            captureSession.stopRunning()
+            captureSession.inputs.forEach { captureSession.removeInput($0) }
+            captureSession.outputs.forEach { captureSession.removeOutput($0) }
+        }
+
+        self.previewLayer?.removeFromSuperlayer()
+        self.previewLayer = nil
+
+        self.frontCameraInput = nil
+        self.rearCameraInput = nil
+        self.audioInput = nil
+
+        self.frontCamera = nil
+        self.rearCamera = nil
+        self.audioDevice = nil
+
+        self.dataOutput = nil
+        self.photoOutput = nil
+        self.fileVideoOutput = nil
+
+        self.captureSession = nil
+        self.currentCameraPosition = nil
     }
 
     func captureVideo() throws {

--- a/ios/Plugin/Plugin.swift
+++ b/ios/Plugin/Plugin.swift
@@ -281,17 +281,19 @@ public class CameraPreview: CAPPlugin, CAPBridgedPlugin {
                 call.reject("camera not initialized")
                 return
             }
-            if self.cameraController.captureSession?.isRunning ?? false {
-                self.cameraController.captureSession?.stopRunning()
-                if let previewView = self.previewView {
-                    previewView.removeFromSuperview()
-                }
-                self.webView?.isOpaque = true
-                self.isInitialized = false
-                call.resolve()
-            } else {
-                call.reject("camera already stopped")
+            
+            // Always attempt to stop and clean up, regardless of captureSession state
+            if let previewView = self.previewView {
+                previewView.removeFromSuperview()
+                self.previewView = nil
             }
+            
+            self.webView?.isOpaque = true
+            self.isInitialized = false
+            self.isInitializing = false
+            self.cameraController.cleanup()
+            
+            call.resolve()
         }
     }
     // Get user's cache directory path


### PR DESCRIPTION
Fixed an issue on IOS where stoping the preview sometime didn't work and didn't reset everything. That means that when trying to start the preview again i got the error "camera already started".

This has been tested on Ipad 10 on IOS 18, but it should work everywhere :)

(based on my issue #187)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved camera cleanup to ensure all resources are released and the camera state is reset when stopped.
	- Stopping the camera now always performs cleanup, even if the camera was already stopped, preventing possible issues with leftover resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->