### PR TITLE
feat: Flip camera IOS working again

### DIFF
--- a/ios/Plugin/CameraController.swift
+++ b/ios/Plugin/CameraController.swift
@@ -297,6 +297,13 @@ extension CameraController {
             guard let frontCamera = frontCamera else {
                 throw CameraControllerError.invalidOperation
             }
+
+            // Configure front camera 
+            try frontCamera.lockForConfiguration()
+            if frontCamera.isFocusModeSupported(.continuousAutoFocus) {
+                frontCamera.focusMode = .continuousAutoFocus
+            }
+            frontCamera.unlockForConfiguration()
             
             let newInput = try AVCaptureDeviceInput(device: frontCamera)
             if captureSession.canAddInput(newInput) {

--- a/ios/Plugin/CameraController.swift
+++ b/ios/Plugin/CameraController.swift
@@ -240,7 +240,6 @@ extension CameraController {
     }
 
     func switchCameras() throws {
-        // Ensure we have a valid session and it's running
         guard let currentCameraPosition = currentCameraPosition,
               let captureSession = self.captureSession else {
             throw CameraControllerError.captureSessionIsMissing
@@ -265,17 +264,12 @@ extension CameraController {
             // Restart the session if it was running before
             if wasRunning {
                 DispatchQueue.global(qos: .userInitiated).async { [weak self] in
-                    guard let self = self else { return }
-                    do {
-                        try self.captureSession?.startRunning()
-                    } catch {
-                        print("Failed to restart capture session: \(error.localizedDescription)")
-                    }
+                    self?.captureSession?.startRunning()
                 }
             }
         }
         
-        // Remove all existing inputs
+        // Remove all inputs
         captureSession.inputs.forEach { captureSession.removeInput($0) }
         
         // Configure new camera
@@ -290,9 +284,10 @@ extension CameraController {
             rearCamera.focusMode = .continuousAutoFocus
             rearCamera.unlockForConfiguration()
             
-            rearCameraInput = try AVCaptureDeviceInput(device: rearCamera)
-            if captureSession.canAddInput(rearCameraInput!) {
-                captureSession.addInput(rearCameraInput!)
+            let newInput = try AVCaptureDeviceInput(device: rearCamera)
+            if captureSession.canAddInput(newInput) {
+                captureSession.addInput(newInput)
+                rearCameraInput = newInput
                 self.currentCameraPosition = .rear
             } else {
                 throw CameraControllerError.invalidOperation
@@ -303,9 +298,10 @@ extension CameraController {
                 throw CameraControllerError.invalidOperation
             }
             
-            frontCameraInput = try AVCaptureDeviceInput(device: frontCamera)
-            if captureSession.canAddInput(frontCameraInput!) {
-                captureSession.addInput(frontCameraInput!)
+            let newInput = try AVCaptureDeviceInput(device: frontCamera)
+            if captureSession.canAddInput(newInput) {
+                captureSession.addInput(newInput)
+                frontCameraInput = newInput
                 self.currentCameraPosition = .front
             } else {
                 throw CameraControllerError.invalidOperation


### PR DESCRIPTION
On my app i had many issues trying to flip the camera on IOS. Sometime it took 10+ seconds to flip, sometimes the preview froze, it was simply not realiable. This PR fixes all of theses issues and makes the flip of camera in an instant. 

I've tested this on my Ipad 10 IOS 18. 

Please note that this time i used AI to help me, so if you plan on accepting this make sure to double-check and test everything :)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved camera orientation handling for better reliability on iOS devices.
  - Enhanced camera switching to provide more robust error handling and prevent crashes.
- **Refactor**
  - Updated deprecated orientation APIs to ensure compatibility with newer iOS versions.
  - Improved thread safety and state management during camera operations.
- **User Experience**
  - Camera flip action now provides smoother transitions and better error feedback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->