### PR TITLE
fix(ios): Fixed issue that caused crash of app on destroy of preview.

### DIFF
--- a/ios/Plugin/Plugin.swift
+++ b/ios/Plugin/Plugin.swift
@@ -69,18 +69,24 @@ public class CameraPreview: CAPPlugin, CAPBridgedPlugin {
     var disableAudio: Bool = false
 
     @objc func rotated() {
-        let height = self.paddingBottom != nil ? self.height! - self.paddingBottom!: self.height!
+        guard let previewView = self.previewView,
+              let posX = self.posX,
+              let posY = self.posY,
+              let width = self.width,
+              let heightValue = self.height else {
+            return
+        }
+        let paddingBottom = self.paddingBottom ?? 0
+        let height = heightValue - paddingBottom
 
         if UIWindow.isLandscape {
-            self.previewView.frame = CGRect(x: self.posY!, y: self.posX!, width: max(height, self.width!), height: min(height, self.width!))
-            self.cameraController.previewLayer?.frame = self.previewView.frame
+            previewView.frame = CGRect(x: posY, y: posX, width: max(height, width), height: min(height, width))
+            self.cameraController.previewLayer?.frame = previewView.frame
         }
 
         if UIWindow.isPortrait {
-            if self.previewView != nil && self.posX != nil && self.posY != nil && self.width != nil && self.height != nil {
-                self.previewView.frame = CGRect(x: self.posX!, y: self.posY!, width: min(height, self.width!), height: max(height, self.width!))
-            }
-            self.cameraController.previewLayer?.frame = self.previewView.frame
+            previewView.frame = CGRect(x: posX, y: posY, width: min(height, width), height: max(height, width))
+            self.cameraController.previewLayer?.frame = previewView.frame
         }
 
         if let connection = self.cameraController.fileVideoOutput?.connection(with: .video) {


### PR DESCRIPTION
On IOS there was an issue and sometimes when destroying the camera preview the app crashed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved the stability and reliability of the camera preview by enhancing how its display area is calculated and updated, resulting in safer and more consistent camera behavior across different orientations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->