### PR TITLE
feat: add exposure management

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,6 +33,10 @@ jobs:
       - name: Check out
         uses: actions/checkout@v5
       - uses: oven-sh/setup-bun@v2
+      - name: Setup Xcode
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: latest-stable
       - uses: actions/cache@v4
         id: cocoapods-cache
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,6 +31,10 @@ jobs:
       - name: Check out
         uses: actions/checkout@v5
       - uses: oven-sh/setup-bun@v2
+      - name: Setup Xcode
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: latest-stable
       - name: Install dependencies
         id: install_code
         run: bun i

--- a/README.md
+++ b/README.md
@@ -888,7 +888,7 @@ getExposureModes() => Promise<{ modes: ("AUTO" | "LOCK" | "CONTINUOUS" | "CUSTOM
 ```
 
 Returns the exposure modes supported by the active camera.
-Modes can include: 'locked', 'auto', 'continuous', 'custom'.
+Modes can include: 'LOCK', 'AUTO', 'CONTINUOUS', 'CUSTOM'.
 
 **Returns:** <code>Promise&lt;{ modes: ('AUTO' | 'LOCK' | 'CONTINUOUS' | 'CUSTOM')[]; }&gt;</code>
 

--- a/README.md
+++ b/README.md
@@ -95,6 +95,53 @@ await CameraPreview.deleteFile({ path: filePath })
 ```
 
 
+## Exposure controls (iOS & Android)
+
+This plugin exposes camera exposure controls on iOS and Android:
+
+- Exposure modes: `"AUTO" | "LOCK" | "CONTINUOUS" | "CUSTOM"`
+- Exposure compensation (EV bias): get range `{ min, max, step }`, read current value, and set new value
+
+Platform notes:
+
+- iOS: The camera starts in `CONTINUOUS` by default. Switching to `AUTO` or `CONTINUOUS` resets EV to 0. The `step` value is approximated to 0.1 since iOS does not expose the bias step.
+- Android: AE lock/unlock and mode are handled via CameraX + Camera2 interop. The `step` value comes from CameraX `ExposureState` and may vary per device.
+
+Example (TypeScript):
+
+```ts
+import { CameraPreview } from '@capgo/camera-preview';
+
+// Query supported modes
+const { modes } = await CameraPreview.getExposureModes();
+console.log('Supported exposure modes:', modes);
+
+// Get current mode
+const { mode } = await CameraPreview.getExposureMode();
+console.log('Current exposure mode:', mode);
+
+// Set mode (AUTO | LOCK | CONTINUOUS | CUSTOM)
+await CameraPreview.setExposureMode({ mode: 'CONTINUOUS' });
+
+// Get EV range (with step)
+const { min, max, step } = await CameraPreview.getExposureCompensationRange();
+console.log('EV range:', { min, max, step });
+
+// Read current EV
+const { value: currentEV } = await CameraPreview.getExposureCompensation();
+console.log('Current EV:', currentEV);
+
+// Increment EV by one step and clamp to range
+const nextEV = Math.max(min, Math.min(max, currentEV + step));
+await CameraPreview.setExposureCompensation({ value: nextEV });
+```
+
+Example app (Ionic):
+
+- Exposure mode toggle (sun icon) cycles through modes.
+- EV controls (+/−) are placed in a top‑right floating action bar, outside the preview area.
+
+
 # Installation
 
 ```
@@ -267,6 +314,12 @@ Documentation for the [uploader](https://github.com/Cap-go/capacitor-uploader)
 * [`deleteFile(...)`](#deletefile)
 * [`getSafeAreaInsets()`](#getsafeareainsets)
 * [`getOrientation()`](#getorientation)
+* [`getExposureModes()`](#getexposuremodes)
+* [`getExposureMode()`](#getexposuremode)
+* [`setExposureMode(...)`](#setexposuremode)
+* [`getExposureCompensationRange()`](#getexposurecompensationrange)
+* [`getExposureCompensation()`](#getexposurecompensation)
+* [`setExposureCompensation(...)`](#setexposurecompensation)
 * [Interfaces](#interfaces)
 * [Type Aliases](#type-aliases)
 * [Enums](#enums)
@@ -824,6 +877,89 @@ Gets the current device orientation in a cross-platform format.
 **Returns:** <code>Promise&lt;{ orientation: <a href="#deviceorientation">DeviceOrientation</a>; }&gt;</code>
 
 **Since:** 7.5.0
+
+--------------------
+
+
+### getExposureModes()
+
+```typescript
+getExposureModes() => Promise<{ modes: ("AUTO" | "LOCK" | "CONTINUOUS" | "CUSTOM")[]; }>
+```
+
+Returns the exposure modes supported by the active camera.
+Modes can include: 'locked', 'auto', 'continuous', 'custom'.
+
+**Returns:** <code>Promise&lt;{ modes: ('AUTO' | 'LOCK' | 'CONTINUOUS' | 'CUSTOM')[]; }&gt;</code>
+
+--------------------
+
+
+### getExposureMode()
+
+```typescript
+getExposureMode() => Promise<{ mode: "AUTO" | "LOCK" | "CONTINUOUS" | "CUSTOM"; }>
+```
+
+Returns the current exposure mode.
+
+**Returns:** <code>Promise&lt;{ mode: 'AUTO' | 'LOCK' | 'CONTINUOUS' | 'CUSTOM'; }&gt;</code>
+
+--------------------
+
+
+### setExposureMode(...)
+
+```typescript
+setExposureMode(options: { mode: "AUTO" | "LOCK" | "CONTINUOUS" | "CUSTOM"; }) => Promise<void>
+```
+
+Sets the exposure mode.
+
+| Param         | Type                                                                 |
+| ------------- | -------------------------------------------------------------------- |
+| **`options`** | <code>{ mode: 'AUTO' \| 'LOCK' \| 'CONTINUOUS' \| 'CUSTOM'; }</code> |
+
+--------------------
+
+
+### getExposureCompensationRange()
+
+```typescript
+getExposureCompensationRange() => Promise<{ min: number; max: number; step: number; }>
+```
+
+Returns the exposure compensation (EV bias) supported range.
+
+**Returns:** <code>Promise&lt;{ min: number; max: number; step: number; }&gt;</code>
+
+--------------------
+
+
+### getExposureCompensation()
+
+```typescript
+getExposureCompensation() => Promise<{ value: number; }>
+```
+
+Returns the current exposure compensation (EV bias).
+
+**Returns:** <code>Promise&lt;{ value: number; }&gt;</code>
+
+--------------------
+
+
+### setExposureCompensation(...)
+
+```typescript
+setExposureCompensation(options: { value: number; }) => Promise<void>
+```
+
+Sets the exposure compensation (EV bias). Value will be clamped to range.
+
+| Param         | Type                            |
+| ------------- | ------------------------------- |
+| **`options`** | <code>{ value: number; }</code> |
 
 --------------------
 

--- a/android/src/main/java/com/ahm/capacitor/camera/preview/CameraPreview.java
+++ b/android/src/main/java/com/ahm/capacitor/camera/preview/CameraPreview.java
@@ -82,6 +82,101 @@ public class CameraPreview
   private int lastOrientation = Configuration.ORIENTATION_UNDEFINED;
 
   @PluginMethod
+  public void getExposureModes(PluginCall call) {
+    if (cameraXView == null || !cameraXView.isRunning()) {
+      call.reject("Camera is not running");
+      return;
+    }
+    JSArray arr = new JSArray();
+    for (String m : cameraXView.getExposureModes()) arr.put(m);
+    JSObject ret = new JSObject();
+    ret.put("modes", arr);
+    call.resolve(ret);
+  }
+
+  @PluginMethod
+  public void getExposureMode(PluginCall call) {
+    if (cameraXView == null || !cameraXView.isRunning()) {
+      call.reject("Camera is not running");
+      return;
+    }
+    JSObject ret = new JSObject();
+    ret.put("mode", cameraXView.getExposureMode());
+    call.resolve(ret);
+  }
+
+  @PluginMethod
+  public void setExposureMode(PluginCall call) {
+    if (cameraXView == null || !cameraXView.isRunning()) {
+      call.reject("Camera is not running");
+      return;
+    }
+    String mode = call.getString("mode");
+    if (mode == null || mode.isEmpty()) {
+      call.reject("mode parameter is required");
+      return;
+    }
+    try {
+      cameraXView.setExposureMode(mode);
+      call.resolve();
+    } catch (Exception e) {
+      call.reject("Failed to set exposure mode: " + e.getMessage());
+    }
+  }
+
+  @PluginMethod
+  public void getExposureCompensationRange(PluginCall call) {
+    if (cameraXView == null || !cameraXView.isRunning()) {
+      call.reject("Camera is not running");
+      return;
+    }
+    try {
+      float[] range = cameraXView.getExposureCompensationRange();
+      JSObject ret = new JSObject();
+      ret.put("min", range[0]);
+      ret.put("max", range[1]);
+      ret.put("step", range.length > 2 ? range[2] : 0.1);
+      call.resolve(ret);
+    } catch (Exception e) {
+      call.reject("Failed to get exposure compensation range: " + e.getMessage());
+    }
+  }
+
+  @PluginMethod
+  public void getExposureCompensation(PluginCall call) {
+    if (cameraXView == null || !cameraXView.isRunning()) {
+      call.reject("Camera is not running");
+      return;
+    }
+    try {
+      float value = cameraXView.getExposureCompensation();
+      JSObject ret = new JSObject();
+      ret.put("value", value);
+      call.resolve(ret);
+    } catch (Exception e) {
+      call.reject("Failed to get exposure compensation: " + e.getMessage());
+    }
+  }
+
+  @PluginMethod
+  public void setExposureCompensation(PluginCall call) {
+    if (cameraXView == null || !cameraXView.isRunning()) {
+      call.reject("Camera is not running");
+      return;
+    }
+    Float value = call.getFloat("value");
+    if (value == null) {
+      call.reject("value parameter is required");
+      return;
+    }
+    try {
+      cameraXView.setExposureCompensation(value);
+      call.resolve();
+    } catch (Exception e) {
+      call.reject("Failed to set exposure compensation: " + e.getMessage());
+    }
+  }
+
   public void getOrientation(PluginCall call) {
     int orientation = getContext()
       .getResources()

--- a/android/src/main/java/com/ahm/capacitor/camera/preview/CameraPreview.java
+++ b/android/src/main/java/com/ahm/capacitor/camera/preview/CameraPreview.java
@@ -138,7 +138,9 @@ public class CameraPreview
       ret.put("step", range.length > 2 ? range[2] : 0.1);
       call.resolve(ret);
     } catch (Exception e) {
-      call.reject("Failed to get exposure compensation range: " + e.getMessage());
+      call.reject(
+        "Failed to get exposure compensation range: " + e.getMessage()
+      );
     }
   }
 

--- a/android/src/main/java/com/ahm/capacitor/camera/preview/CameraXView.java
+++ b/android/src/main/java/com/ahm/capacitor/camera/preview/CameraXView.java
@@ -1927,7 +1927,7 @@ public class CameraXView implements LifecycleOwner, LifecycleObserver {
             .setCaptureRequestOption(CaptureRequest.CONTROL_AE_LOCK, true)
             .setCaptureRequestOption(CaptureRequest.CONTROL_AE_MODE, CaptureRequest.CONTROL_AE_MODE_ON)
             .build();
-          c2.setCaptureRequestOptions(opts);
+          mainExecutor.execute(() -> c2.setCaptureRequestOptions(opts));
           currentExposureMode = "LOCK";
           break;
         }
@@ -1936,7 +1936,7 @@ public class CameraXView implements LifecycleOwner, LifecycleObserver {
             .setCaptureRequestOption(CaptureRequest.CONTROL_AE_LOCK, false)
             .setCaptureRequestOption(CaptureRequest.CONTROL_AE_MODE, CaptureRequest.CONTROL_AE_MODE_ON)
             .build();
-          c2.setCaptureRequestOptions(opts);
+          mainExecutor.execute(() -> c2.setCaptureRequestOptions(opts));
           currentExposureMode = "CONTINUOUS";
           break;
         }

--- a/android/src/main/java/com/ahm/capacitor/camera/preview/CameraXView.java
+++ b/android/src/main/java/com/ahm/capacitor/camera/preview/CameraXView.java
@@ -12,6 +12,7 @@ import android.graphics.drawable.GradientDrawable;
 import android.hardware.camera2.CameraAccessException;
 import android.hardware.camera2.CameraCharacteristics;
 import android.hardware.camera2.CameraManager;
+import android.hardware.camera2.CaptureRequest;
 import android.location.Location;
 import android.media.MediaScannerConnection;
 import android.os.Build;
@@ -19,6 +20,8 @@ import android.os.Environment;
 import android.util.Base64;
 import android.util.DisplayMetrics;
 import android.util.Log;
+import android.util.Range;
+import android.util.Rational;
 import android.util.Size;
 import android.view.MotionEvent;
 import android.view.View;
@@ -30,15 +33,15 @@ import android.widget.FrameLayout;
 import androidx.annotation.NonNull;
 import androidx.annotation.OptIn;
 import androidx.annotation.RequiresApi;
-import androidx.camera.camera2.interop.Camera2CameraInfo;
-import androidx.camera.camera2.interop.ExperimentalCamera2Interop;
 import androidx.camera.camera2.interop.Camera2CameraControl;
+import androidx.camera.camera2.interop.Camera2CameraInfo;
 import androidx.camera.camera2.interop.CaptureRequestOptions;
-import android.hardware.camera2.CaptureRequest;
+import androidx.camera.camera2.interop.ExperimentalCamera2Interop;
 import androidx.camera.core.AspectRatio;
 import androidx.camera.core.Camera;
 import androidx.camera.core.CameraInfo;
 import androidx.camera.core.CameraSelector;
+import androidx.camera.core.ExposureState;
 import androidx.camera.core.FocusMeteringAction;
 import androidx.camera.core.FocusMeteringResult;
 import androidx.camera.core.ImageCapture;
@@ -72,6 +75,7 @@ import java.nio.ByteBuffer;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
@@ -80,10 +84,6 @@ import java.util.Set;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import java.util.Arrays;
-import android.util.Range;
-import android.util.Rational;
-import androidx.camera.core.ExposureState;
 import org.json.JSONObject;
 
 public class CameraXView implements LifecycleOwner, LifecycleObserver {
@@ -1822,7 +1822,9 @@ public class CameraXView implements LifecycleOwner, LifecycleObserver {
       int zeroIdx = 0;
       if (range != null && !range.contains(0)) {
         // Choose the closest index to 0 if 0 is not available
-        zeroIdx = Math.abs(range.getLower()) < Math.abs(range.getUpper()) ? range.getLower() : range.getUpper();
+        zeroIdx = Math.abs(range.getLower()) < Math.abs(range.getUpper())
+          ? range.getLower()
+          : range.getUpper();
       }
       camera.getCameraControl().setExposureCompensationIndex(zeroIdx);
     } catch (Exception e) {
@@ -1920,12 +1922,17 @@ public class CameraXView implements LifecycleOwner, LifecycleObserver {
     String normalized = mode.toUpperCase(Locale.US);
 
     try {
-      Camera2CameraControl c2 = Camera2CameraControl.from(camera.getCameraControl());
+      Camera2CameraControl c2 = Camera2CameraControl.from(
+        camera.getCameraControl()
+      );
       switch (normalized) {
         case "LOCK": {
           CaptureRequestOptions opts = new CaptureRequestOptions.Builder()
             .setCaptureRequestOption(CaptureRequest.CONTROL_AE_LOCK, true)
-            .setCaptureRequestOption(CaptureRequest.CONTROL_AE_MODE, CaptureRequest.CONTROL_AE_MODE_ON)
+            .setCaptureRequestOption(
+              CaptureRequest.CONTROL_AE_MODE,
+              CaptureRequest.CONTROL_AE_MODE_ON
+            )
             .build();
           c2.setCaptureRequestOptions(opts);
           currentExposureMode = "LOCK";
@@ -1934,7 +1941,10 @@ public class CameraXView implements LifecycleOwner, LifecycleObserver {
         case "CONTINUOUS": {
           CaptureRequestOptions opts = new CaptureRequestOptions.Builder()
             .setCaptureRequestOption(CaptureRequest.CONTROL_AE_LOCK, false)
-            .setCaptureRequestOption(CaptureRequest.CONTROL_AE_MODE, CaptureRequest.CONTROL_AE_MODE_ON)
+            .setCaptureRequestOption(
+              CaptureRequest.CONTROL_AE_MODE,
+              CaptureRequest.CONTROL_AE_MODE_ON
+            )
             .build();
           c2.setCaptureRequestOptions(opts);
           currentExposureMode = "CONTINUOUS";
@@ -1955,7 +1965,9 @@ public class CameraXView implements LifecycleOwner, LifecycleObserver {
     ExposureState state = camera.getCameraInfo().getExposureState();
     Range<Integer> idxRange = state.getExposureCompensationRange();
     Rational step = state.getExposureCompensationStep();
-    float evStep = step != null ? (float) step.getNumerator() / (float) step.getDenominator() : 1.0f;
+    float evStep = step != null
+      ? (float) step.getNumerator() / (float) step.getDenominator()
+      : 1.0f;
     float min = idxRange.getLower() * evStep;
     float max = idxRange.getUpper() * evStep;
     return new float[] { min, max, evStep };
@@ -1968,7 +1980,9 @@ public class CameraXView implements LifecycleOwner, LifecycleObserver {
     ExposureState state = camera.getCameraInfo().getExposureState();
     int idx = state.getExposureCompensationIndex();
     Rational step = state.getExposureCompensationStep();
-    float evStep = step != null ? (float) step.getNumerator() / (float) step.getDenominator() : 1.0f;
+    float evStep = step != null
+      ? (float) step.getNumerator() / (float) step.getDenominator()
+      : 1.0f;
     return idx * evStep;
   }
 
@@ -1979,7 +1993,9 @@ public class CameraXView implements LifecycleOwner, LifecycleObserver {
     ExposureState state = camera.getCameraInfo().getExposureState();
     Range<Integer> idxRange = state.getExposureCompensationRange();
     Rational step = state.getExposureCompensationStep();
-    float evStep = step != null ? (float) step.getNumerator() / (float) step.getDenominator() : 1.0f;
+    float evStep = step != null
+      ? (float) step.getNumerator() / (float) step.getDenominator()
+      : 1.0f;
     if (evStep <= 0f) evStep = 1.0f;
     int idx = Math.round(ev / evStep);
     // clamp

--- a/example-app/src/app/components/camera-modal/camera-modal.component.html
+++ b/example-app/src/app/components/camera-modal/camera-modal.component.html
@@ -309,4 +309,37 @@
       <span>{{ isHalfSize() ? "Extend" : "Small" }}</span>
     </ion-fab-button>
   </ion-fab>
+
+  <!-- Exposure EV Controls Outside Preview Bounds -->
+<ion-fab
+  class="ev-controls"
+  slot="fixed"
+  horizontal="end"
+  vertical="bottom"
+>
+    <!-- Exposure Mode Toggle -->
+    <ion-fab-button (click)="cycleExposureMode()" size="small" aria-label="Cycle exposure mode">
+      <div style="line-height: 0.5; margin-top: -5px; text-align:center">
+        <ion-icon name="sunny-outline" size="small"></ion-icon><br />
+        <span style="font-size: 0.6rem">{{ exposureMode() }}</span>
+      </div>
+    </ion-fab-button>
+    <!-- Decrease / Increase EV -->
+    <ion-fab-button
+      (click)="decreaseEV()"
+      size="small"
+      [disabled]="currentEV() <= exposureMin"
+      aria-label="Decrease exposure"
+    >
+      <ion-icon name="remove"></ion-icon>
+    </ion-fab-button>
+    <ion-fab-button
+      (click)="increaseEV()"
+      size="small"
+      [disabled]="currentEV() >= exposureMax"
+      aria-label="Increase exposure"
+    >
+      <ion-icon name="add"></ion-icon>
+    </ion-fab-button>
+</ion-fab>
 </div>

--- a/example-app/src/app/components/camera-modal/camera-modal.component.html
+++ b/example-app/src/app/components/camera-modal/camera-modal.component.html
@@ -324,6 +324,13 @@
         <span style="font-size: 0.6rem">{{ exposureMode() }}</span>
       </div>
     </ion-fab-button>
+    <!-- EV readout -->
+    <ion-fab-button size="small" [disabled]="true" aria-label="Current exposure value">
+      <div style="line-height: 1; text-align:center">
+        <span style="font-size: 0.6rem">EV</span><br />
+        <span style="font-size: 0.8rem">{{ (currentEV() | number:'1.1-1') }}</span>
+      </div>
+    </ion-fab-button>
     <!-- Decrease / Increase EV -->
     <ion-fab-button
       (click)="decreaseEV()"

--- a/example-app/src/app/components/camera-modal/camera-modal.component.html
+++ b/example-app/src/app/components/camera-modal/camera-modal.component.html
@@ -324,13 +324,6 @@
         <span style="font-size: 0.6rem">{{ exposureMode() }}</span>
       </div>
     </ion-fab-button>
-    <!-- EV readout -->
-    <ion-fab-button size="small" [disabled]="true" aria-label="Current exposure value">
-      <div style="line-height: 1; text-align:center">
-        <span style="font-size: 0.6rem">EV</span><br />
-        <span style="font-size: 0.8rem">{{ (currentEV() | number:'1.1-1') }}</span>
-      </div>
-    </ion-fab-button>
     <!-- Decrease / Increase EV -->
     <ion-fab-button
       (click)="decreaseEV()"

--- a/example-app/src/app/components/camera-modal/camera-modal.component.scss
+++ b/example-app/src/app/components/camera-modal/camera-modal.component.scss
@@ -459,6 +459,10 @@ ion-fab-button {
   }
 }
 
+.ev-controls {
+  display: flex;
+}
+
 // High contrast mode for better visibility
 @media (prefers-contrast: high) {
   .floating-info-panel ion-card {

--- a/example-app/src/app/components/camera-modal/camera-modal.component.ts
+++ b/example-app/src/app/components/camera-modal/camera-modal.component.ts
@@ -381,9 +381,11 @@ export class CameraModalComponent implements OnInit, OnDestroy {
     } catch {}
     try {
       const range = await this.#cameraViewService.getExposureCompensationRange();
-      this.exposureMin = range.min;
-      this.exposureMax = range.max;
-      this.exposureStep = range.step ?? 0.1;
+      const min = Math.min(range.min, range.max);
+      const max = Math.max(range.min, range.max);
+      this.exposureMin = min;
+      this.exposureMax = max;
+      this.exposureStep = range.step && range.step > 0 ? range.step : 0.1;
     } catch {}
     try {
       const value = await this.#cameraViewService.getExposureCompensation();

--- a/example-app/src/app/components/camera-modal/camera-modal.component.ts
+++ b/example-app/src/app/components/camera-modal/camera-modal.component.ts
@@ -405,9 +405,13 @@ export class CameraModalComponent implements OnInit, OnDestroy {
 
   protected async increaseEV(): Promise<void> {
     try {
-      const next = Math.min(this.currentEV() + this.exposureStep, this.exposureMax);
-      await this.#cameraViewService.setExposureCompensation(next);
-      this.currentEV.set(next);
+      if (this.exposureMode() === 'LOCK' || this.exposureMode() === 'CUSTOM') return;
+      const raw = Math.min(this.currentEV() + this.exposureStep, this.exposureMax);
+      const step = this.exposureStep || 0.1;
+      const snapped = Math.max(this.exposureMin,
+        Math.min(this.exposureMax, Math.round(raw / step) * step));
+      await this.#cameraViewService.setExposureCompensation(snapped);
+      this.currentEV.set(Number(snapped.toFixed(3)));
     } catch (e) {
       console.warn('Failed to increase EV', e);
     }
@@ -415,9 +419,13 @@ export class CameraModalComponent implements OnInit, OnDestroy {
 
   protected async decreaseEV(): Promise<void> {
     try {
-      const next = Math.max(this.currentEV() - this.exposureStep, this.exposureMin);
-      await this.#cameraViewService.setExposureCompensation(next);
-      this.currentEV.set(next);
+      if (this.exposureMode() === 'LOCK' || this.exposureMode() === 'CUSTOM') return;
+      const raw = Math.max(this.currentEV() - this.exposureStep, this.exposureMin);
+      const step = this.exposureStep || 0.1;
+      const snapped = Math.max(this.exposureMin,
+        Math.min(this.exposureMax, Math.round(raw / step) * step));
+      await this.#cameraViewService.setExposureCompensation(snapped);
+      this.currentEV.set(Number(snapped.toFixed(3)));
     } catch (e) {
       console.warn('Failed to decrease EV', e);
     }

--- a/example-app/src/app/components/camera-modal/camera-modal.component.ts
+++ b/example-app/src/app/components/camera-modal/camera-modal.component.ts
@@ -118,6 +118,12 @@ export class CameraModalComponent implements OnInit, OnDestroy {
   protected readonly currentOpacity = signal(100);
   protected readonly testResults = signal<string>('');
   protected readonly showTestResults = signal(false);
+  // Exposure state
+  protected readonly exposureMode = signal<'AUTO' | 'LOCK' | 'CONTINUOUS' | 'CUSTOM'>('CONTINUOUS');
+  protected exposureMin = 0;
+  protected exposureMax = 0;
+  protected exposureStep = 0.1;
+  protected currentEV = signal<number>(0);
 
   // Camera switching functionality
   protected readonly availableCameras = signal<CameraDevice[]>([]);
@@ -350,6 +356,7 @@ export class CameraModalComponent implements OnInit, OnDestroy {
         this.#updateRunningStatus(),
         this.#updateCurrentDeviceId(),
         this.#initializeCurrentPreviewSize(),
+        this.#initializeExposureControls(),
       ]);
 
       this.currentZoomFactor.set(this.initialZoomFactor());
@@ -364,6 +371,55 @@ export class CameraModalComponent implements OnInit, OnDestroy {
         error: error instanceof Error ? error.message : String(error),
         type: 'error',
       });
+    }
+  }
+
+  async #initializeExposureControls(): Promise<void> {
+    try {
+      const mode = await this.#cameraViewService.getExposureMode();
+      this.exposureMode.set(mode);
+    } catch {}
+    try {
+      const range = await this.#cameraViewService.getExposureCompensationRange();
+      this.exposureMin = range.min;
+      this.exposureMax = range.max;
+      this.exposureStep = range.step ?? 0.1;
+    } catch {}
+    try {
+      const value = await this.#cameraViewService.getExposureCompensation();
+      this.currentEV.set(value);
+    } catch {}
+  }
+
+  protected async cycleExposureMode(): Promise<void> {
+    try {
+      const modes = await this.#cameraViewService.getExposureModes();
+      const idx = modes.indexOf(this.exposureMode());
+      const next = modes[(idx + 1) % modes.length] as 'AUTO' | 'LOCK' | 'CONTINUOUS' | 'CUSTOM';
+      await this.#cameraViewService.setExposureMode(next);
+      this.exposureMode.set(next);
+    } catch (e) {
+      console.warn('Failed to set exposure mode', e);
+    }
+  }
+
+  protected async increaseEV(): Promise<void> {
+    try {
+      const next = Math.min(this.currentEV() + this.exposureStep, this.exposureMax);
+      await this.#cameraViewService.setExposureCompensation(next);
+      this.currentEV.set(next);
+    } catch (e) {
+      console.warn('Failed to increase EV', e);
+    }
+  }
+
+  protected async decreaseEV(): Promise<void> {
+    try {
+      const next = Math.max(this.currentEV() - this.exposureStep, this.exposureMin);
+      await this.#cameraViewService.setExposureCompensation(next);
+      this.currentEV.set(next);
+    } catch (e) {
+      console.warn('Failed to decrease EV', e);
     }
   }
 

--- a/example-app/src/app/core/capacitor-camera-preview.service.ts
+++ b/example-app/src/app/core/capacitor-camera-preview.service.ts
@@ -9,6 +9,7 @@ import {
   LensInfo,
   CameraPreviewPlugin,
   GridMode,
+  ExposureMode,
   getBase64FromFilePath,
   deleteFile,
 } from '@capgo/camera-preview';
@@ -292,30 +293,30 @@ export class CapacitorCameraViewService {
   }
 
   // ===== Exposure controls =====
-  async getExposureModes(): Promise<Array<'AUTO' | 'LOCK' | 'CONTINUOUS' | 'CUSTOM'>> {
-    const res = await (this.#cameraView as any).getExposureModes();
-    return res.modes as Array<'AUTO' | 'LOCK' | 'CONTINUOUS' | 'CUSTOM'>;
+  async getExposureModes(): Promise<ExposureMode[]> {
+    const { modes } = await this.#cameraView.getExposureModes();
+    return modes;
   }
 
-  async getExposureMode(): Promise<'AUTO' | 'LOCK' | 'CONTINUOUS' | 'CUSTOM'> {
-    const res = await (this.#cameraView as any).getExposureMode();
-    return res.mode as 'AUTO' | 'LOCK' | 'CONTINUOUS' | 'CUSTOM';
+  async getExposureMode(): Promise<ExposureMode> {
+    const { mode } = await this.#cameraView.getExposureMode();
+    return mode;
   }
 
-  async setExposureMode(mode: 'AUTO' | 'LOCK' | 'CONTINUOUS' | 'CUSTOM'): Promise<void> {
-    await (this.#cameraView as any).setExposureMode({ mode });
+  async setExposureMode(mode: ExposureMode): Promise<void> {
+    await this.#cameraView.setExposureMode({ mode });
   }
 
   async getExposureCompensationRange(): Promise<{ min: number; max: number; step: number }> {
-    return await (this.#cameraView as any).getExposureCompensationRange();
+    return await this.#cameraView.getExposureCompensationRange();
   }
 
   async getExposureCompensation(): Promise<number> {
-    const res = await (this.#cameraView as any).getExposureCompensation();
-    return res.value as number;
+    const { value } = await this.#cameraView.getExposureCompensation();
+    return value;
   }
 
   async setExposureCompensation(value: number): Promise<void> {
-    await (this.#cameraView as any).setExposureCompensation({ value });
+    await this.#cameraView.setExposureCompensation({ value });
   }
 }

--- a/example-app/src/app/core/capacitor-camera-preview.service.ts
+++ b/example-app/src/app/core/capacitor-camera-preview.service.ts
@@ -290,4 +290,32 @@ export class CapacitorCameraViewService {
   async deleteFile(filePath: string): Promise<boolean> {
     return deleteFile(filePath);
   }
+
+  // ===== Exposure controls =====
+  async getExposureModes(): Promise<Array<'AUTO' | 'LOCK' | 'CONTINUOUS' | 'CUSTOM'>> {
+    const res = await (this.#cameraView as any).getExposureModes();
+    return res.modes as Array<'AUTO' | 'LOCK' | 'CONTINUOUS' | 'CUSTOM'>;
+  }
+
+  async getExposureMode(): Promise<'AUTO' | 'LOCK' | 'CONTINUOUS' | 'CUSTOM'> {
+    const res = await (this.#cameraView as any).getExposureMode();
+    return res.mode as 'AUTO' | 'LOCK' | 'CONTINUOUS' | 'CUSTOM';
+  }
+
+  async setExposureMode(mode: 'AUTO' | 'LOCK' | 'CONTINUOUS' | 'CUSTOM'): Promise<void> {
+    await (this.#cameraView as any).setExposureMode({ mode });
+  }
+
+  async getExposureCompensationRange(): Promise<{ min: number; max: number; step: number }> {
+    return await (this.#cameraView as any).getExposureCompensationRange();
+  }
+
+  async getExposureCompensation(): Promise<number> {
+    const res = await (this.#cameraView as any).getExposureCompensation();
+    return res.value as number;
+  }
+
+  async setExposureCompensation(value: number): Promise<void> {
+    await (this.#cameraView as any).setExposureCompensation({ value });
+  }
 }

--- a/ios/Sources/CapgoCameraPreviewPlugin/CameraController.swift
+++ b/ios/Sources/CapgoCameraPreviewPlugin/CameraController.swift
@@ -433,8 +433,8 @@ extension CameraController {
         // Set default exposure mode to CONTINUOUS when starting the camera
         do {
             try finalDevice.lockForConfiguration()
-            if finalDevice.isExposureModeSupported(.autoExpose) {
-                finalDevice.exposureMode = .autoExpose
+            if finalDevice.isExposureModeSupported(.continuousAutoExposure) {
+                finalDevice.exposureMode = .continuousAutoExposure
                 if finalDevice.isExposurePointOfInterestSupported {
                     finalDevice.exposurePointOfInterest = CGPoint(x: 0.5, y: 0.5)
                 }

--- a/ios/Sources/CapgoCameraPreviewPlugin/Plugin.swift
+++ b/ios/Sources/CapgoCameraPreviewPlugin/Plugin.swift
@@ -1844,8 +1844,16 @@ public class CameraPreview: CAPPlugin, CAPBridgedPlugin, CLLocationManagerDelega
             call.reject("mode parameter is required")
             return
         }
+        // Validate against allowed exposure modes before delegating
+        let normalized = mode.uppercased()
+        let allowedModes: Set<String> = ["AUTO", "LOCK", "CONTINUOUS", "CUSTOM"]
+        guard allowedModes.contains(normalized) else {
+            let allowedList = Array(allowedModes).sorted().joined(separator: ", ")
+            call.reject("Invalid exposure mode: \(mode). Allowed values: \(allowedList)")
+            return
+        }
         do {
-            try self.cameraController.setExposureMode(mode: mode)
+            try self.cameraController.setExposureMode(mode: normalized)
             call.resolve()
         } catch {
             call.reject("Failed to set exposure mode: \(error.localizedDescription)")

--- a/ios/Sources/CapgoCameraPreviewPlugin/Plugin.swift
+++ b/ios/Sources/CapgoCameraPreviewPlugin/Plugin.swift
@@ -69,7 +69,14 @@ public class CameraPreview: CAPPlugin, CAPBridgedPlugin, CLLocationManagerDelega
         CAPPluginMethod(name: "setFocus", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "deleteFile", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "getOrientation", returnType: CAPPluginReturnPromise),
-        CAPPluginMethod(name: "getSafeAreaInsets", returnType: CAPPluginReturnPromise)
+        CAPPluginMethod(name: "getSafeAreaInsets", returnType: CAPPluginReturnPromise),
+        // Exposure control methods
+        CAPPluginMethod(name: "getExposureModes", returnType: CAPPluginReturnPromise),
+        CAPPluginMethod(name: "getExposureMode", returnType: CAPPluginReturnPromise),
+        CAPPluginMethod(name: "setExposureMode", returnType: CAPPluginReturnPromise),
+        CAPPluginMethod(name: "getExposureCompensationRange", returnType: CAPPluginReturnPromise),
+        CAPPluginMethod(name: "getExposureCompensation", returnType: CAPPluginReturnPromise),
+        CAPPluginMethod(name: "setExposureCompensation", returnType: CAPPluginReturnPromise)
 
     ]
     // Camera state tracking
@@ -1797,6 +1804,94 @@ public class CameraPreview: CAPPlugin, CAPBridgedPlugin, CLLocationManagerDelega
             } catch {
                 call.reject("Failed to set focus: \(error.localizedDescription)")
             }
+        }
+    }
+
+    // MARK: - Exposure Bridge
+
+    @objc func getExposureModes(_ call: CAPPluginCall) {
+        guard isInitialized else {
+            call.reject("Camera not initialized")
+            return
+        }
+        do {
+            let modes = try self.cameraController.getExposureModes()
+            call.resolve(["modes": modes])
+        } catch {
+            call.reject("Failed to get exposure modes: \(error.localizedDescription)")
+        }
+    }
+
+    @objc func getExposureMode(_ call: CAPPluginCall) {
+        guard isInitialized else {
+            call.reject("Camera not initialized")
+            return
+        }
+        do {
+            let mode = try self.cameraController.getExposureMode()
+            call.resolve(["mode": mode])
+        } catch {
+            call.reject("Failed to get exposure mode: \(error.localizedDescription)")
+        }
+    }
+
+    @objc func setExposureMode(_ call: CAPPluginCall) {
+        guard isInitialized else {
+            call.reject("Camera not initialized")
+            return
+        }
+        guard let mode = call.getString("mode") else {
+            call.reject("mode parameter is required")
+            return
+        }
+        do {
+            try self.cameraController.setExposureMode(mode: mode)
+            call.resolve()
+        } catch {
+            call.reject("Failed to set exposure mode: \(error.localizedDescription)")
+        }
+    }
+
+    @objc func getExposureCompensationRange(_ call: CAPPluginCall) {
+        guard isInitialized else {
+            call.reject("Camera not initialized")
+            return
+        }
+        do {
+            let range = try self.cameraController.getExposureCompensationRange()
+            call.resolve(["min": range.min, "max": range.max, "step": range.step])
+        } catch {
+            call.reject("Failed to get exposure compensation range: \(error.localizedDescription)")
+        }
+    }
+
+    @objc func getExposureCompensation(_ call: CAPPluginCall) {
+        guard isInitialized else {
+            call.reject("Camera not initialized")
+            return
+        }
+        do {
+            let value = try self.cameraController.getExposureCompensation()
+            call.resolve(["value": value])
+        } catch {
+            call.reject("Failed to get exposure compensation: \(error.localizedDescription)")
+        }
+    }
+
+    @objc func setExposureCompensation(_ call: CAPPluginCall) {
+        guard isInitialized else {
+            call.reject("Camera not initialized")
+            return
+        }
+        guard let value = call.getFloat("value") else {
+            call.reject("value parameter is required")
+            return
+        }
+        do {
+            try self.cameraController.setExposureCompensation(value)
+            call.resolve()
+        } catch {
+            call.reject("Failed to set exposure compensation: \(error.localizedDescription)")
         }
     }
 

--- a/ios/Sources/CapgoCameraPreviewPlugin/Plugin.swift
+++ b/ios/Sources/CapgoCameraPreviewPlugin/Plugin.swift
@@ -108,8 +108,6 @@ public class CameraPreview: CAPPlugin, CAPBridgedPlugin, CLLocationManagerDelega
 
     // MARK: - Helper Methods for Aspect Ratio
 
-
-
     /// Parses aspect ratio string and returns the appropriate ratio for the current orientation
     private func parseAspectRatio(_ ratio: String, isPortrait: Bool) -> CGFloat {
         let parts = ratio.split(separator: ":").compactMap { Double($0) }
@@ -592,8 +590,6 @@ public class CameraPreview: CAPPlugin, CAPBridgedPlugin, CLLocationManagerDelega
             call.reject("Cannot set both aspectRatio and size (width/height). Use setPreviewSize after start.")
             return
         }
-
-
 
         AVCaptureDevice.requestAccess(for: .video, completionHandler: { (granted: Bool) in
 

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -707,4 +707,41 @@ export interface CameraPreviewPlugin {
    * @platform android, ios
    */
   getOrientation(): Promise<{ orientation: DeviceOrientation }>;
+
+  /**
+   * Returns the exposure modes supported by the active camera.
+   * Modes can include: 'locked', 'auto', 'continuous', 'custom'.
+   * @platform ios
+   */
+  getExposureModes(): Promise<{ modes: ("AUTO" | "LOCK" | "CONTINUOUS" | "CUSTOM")[] }>;
+
+  /**
+   * Returns the current exposure mode.
+   * @platform ios
+   */
+  getExposureMode(): Promise<{ mode: "AUTO" | "LOCK" | "CONTINUOUS" | "CUSTOM" }>;
+
+  /**
+   * Sets the exposure mode.
+   * @platform ios
+   */
+  setExposureMode(options: { mode: "AUTO" | "LOCK" | "CONTINUOUS" | "CUSTOM" }): Promise<void>;
+
+  /**
+   * Returns the exposure compensation (EV bias) supported range.
+   * @platform ios
+   */
+  getExposureCompensationRange(): Promise<{ min: number; max: number; step: number }>;
+
+  /**
+   * Returns the current exposure compensation (EV bias).
+   * @platform ios
+   */
+  getExposureCompensation(): Promise<{ value: number }>;
+
+  /**
+   * Sets the exposure compensation (EV bias). Value will be clamped to range.
+   * @platform ios
+   */
+  setExposureCompensation(options: { value: number }): Promise<void>;
 }

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -296,6 +296,9 @@ export interface CameraSampleOptions {
  */
 export type CameraPreviewFlashMode = "off" | "on" | "auto" | "torch";
 
+/** Reusable exposure mode type for cross-platform support. */
+export type ExposureMode = "AUTO" | "LOCK" | "CONTINUOUS" | "CUSTOM";
+
 /**
  * Defines the options for setting the camera preview's opacity.
  */
@@ -711,21 +714,21 @@ export interface CameraPreviewPlugin {
   /**
    * Returns the exposure modes supported by the active camera.
    * Modes can include: 'locked', 'auto', 'continuous', 'custom'.
-   * @platform ios
+   * @platform android, ios
    */
-  getExposureModes(): Promise<{ modes: ("AUTO" | "LOCK" | "CONTINUOUS" | "CUSTOM")[] }>;
+  getExposureModes(): Promise<{ modes: ExposureMode[] }>;
 
   /**
    * Returns the current exposure mode.
-   * @platform ios
+   * @platform android, ios
    */
-  getExposureMode(): Promise<{ mode: "AUTO" | "LOCK" | "CONTINUOUS" | "CUSTOM" }>;
+  getExposureMode(): Promise<{ mode: ExposureMode }>;
 
   /**
    * Sets the exposure mode.
-   * @platform ios
+   * @platform android, ios
    */
-  setExposureMode(options: { mode: "AUTO" | "LOCK" | "CONTINUOUS" | "CUSTOM" }): Promise<void>;
+  setExposureMode(options: { mode: ExposureMode }): Promise<void>;
 
   /**
    * Returns the exposure compensation (EV bias) supported range.

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -713,25 +713,35 @@ export interface CameraPreviewPlugin {
    * Modes can include: 'locked', 'auto', 'continuous', 'custom'.
    * @platform ios
    */
-  getExposureModes(): Promise<{ modes: ("AUTO" | "LOCK" | "CONTINUOUS" | "CUSTOM")[] }>;
+  getExposureModes(): Promise<{
+    modes: ("AUTO" | "LOCK" | "CONTINUOUS" | "CUSTOM")[];
+  }>;
 
   /**
    * Returns the current exposure mode.
    * @platform ios
    */
-  getExposureMode(): Promise<{ mode: "AUTO" | "LOCK" | "CONTINUOUS" | "CUSTOM" }>;
+  getExposureMode(): Promise<{
+    mode: "AUTO" | "LOCK" | "CONTINUOUS" | "CUSTOM";
+  }>;
 
   /**
    * Sets the exposure mode.
    * @platform ios
    */
-  setExposureMode(options: { mode: "AUTO" | "LOCK" | "CONTINUOUS" | "CUSTOM" }): Promise<void>;
+  setExposureMode(options: {
+    mode: "AUTO" | "LOCK" | "CONTINUOUS" | "CUSTOM";
+  }): Promise<void>;
 
   /**
    * Returns the exposure compensation (EV bias) supported range.
    * @platform ios
    */
-  getExposureCompensationRange(): Promise<{ min: number; max: number; step: number }>;
+  getExposureCompensationRange(): Promise<{
+    min: number;
+    max: number;
+    step: number;
+  }>;
 
   /**
    * Returns the current exposure compensation (EV bias).

--- a/src/web.ts
+++ b/src/web.ts
@@ -10,6 +10,7 @@ import type {
   CameraSampleOptions,
   DeviceOrientation,
   GridMode,
+  ExposureMode,
   FlashMode,
   LensInfo,
   SafeAreaInsets,
@@ -1202,15 +1203,15 @@ export class CameraPreviewWeb extends WebPlugin implements CameraPreviewPlugin {
   }
 
   // Exposure stubs (unsupported on web)
-  async getExposureModes(): Promise<{ modes: ("AUTO" | "LOCK" | "CONTINUOUS" | "CUSTOM")[] }> {
+  async getExposureModes(): Promise<{ modes: ExposureMode }> {
     throw new Error("getExposureModes not supported under the web platform");
   }
 
-  async getExposureMode(): Promise<{ mode: "AUTO" | "LOCK" | "CONTINUOUS" | "CUSTOM" }> {
+  async getExposureMode(): Promise<{ mode: ExposureMode }> {
     throw new Error("getExposureMode not supported under the web platform");
   }
 
-  async setExposureMode(_options: { mode: "AUTO" | "LOCK" | "CONTINUOUS" | "CUSTOM" }): Promise<void> {
+  async setExposureMode(_options: { mode: ExposureMode }): Promise<void> {
     throw new Error("setExposureMode not supported under the web platform");
   }
 

--- a/src/web.ts
+++ b/src/web.ts
@@ -1201,6 +1201,31 @@ export class CameraPreviewWeb extends WebPlugin implements CameraPreviewPlugin {
     }
   }
 
+  // Exposure stubs (unsupported on web)
+  async getExposureModes(): Promise<{ modes: ("AUTO" | "LOCK" | "CONTINUOUS" | "CUSTOM")[] }> {
+    throw new Error("getExposureModes not supported under the web platform");
+  }
+
+  async getExposureMode(): Promise<{ mode: "AUTO" | "LOCK" | "CONTINUOUS" | "CUSTOM" }> {
+    throw new Error("getExposureMode not supported under the web platform");
+  }
+
+  async setExposureMode(_options: { mode: "AUTO" | "LOCK" | "CONTINUOUS" | "CUSTOM" }): Promise<void> {
+    throw new Error("setExposureMode not supported under the web platform");
+  }
+
+  async getExposureCompensationRange(): Promise<{ min: number; max: number; step: number }> {
+    throw new Error("getExposureCompensationRange not supported under the web platform");
+  }
+
+  async getExposureCompensation(): Promise<{ value: number }> {
+    throw new Error("getExposureCompensation not supported under the web platform");
+  }
+
+  async setExposureCompensation(_options: { value: number }): Promise<void> {
+    throw new Error("setExposureCompensation not supported under the web platform");
+  }
+
   async deleteFile(_options: { path: string }): Promise<{ success: boolean }> {
     // Mark parameter as intentionally unused to satisfy linter
     void _options;

--- a/src/web.ts
+++ b/src/web.ts
@@ -1202,28 +1202,44 @@ export class CameraPreviewWeb extends WebPlugin implements CameraPreviewPlugin {
   }
 
   // Exposure stubs (unsupported on web)
-  async getExposureModes(): Promise<{ modes: ("AUTO" | "LOCK" | "CONTINUOUS" | "CUSTOM")[] }> {
+  async getExposureModes(): Promise<{
+    modes: ("AUTO" | "LOCK" | "CONTINUOUS" | "CUSTOM")[];
+  }> {
     throw new Error("getExposureModes not supported under the web platform");
   }
 
-  async getExposureMode(): Promise<{ mode: "AUTO" | "LOCK" | "CONTINUOUS" | "CUSTOM" }> {
+  async getExposureMode(): Promise<{
+    mode: "AUTO" | "LOCK" | "CONTINUOUS" | "CUSTOM";
+  }> {
     throw new Error("getExposureMode not supported under the web platform");
   }
 
-  async setExposureMode(_options: { mode: "AUTO" | "LOCK" | "CONTINUOUS" | "CUSTOM" }): Promise<void> {
+  async setExposureMode(_options: {
+    mode: "AUTO" | "LOCK" | "CONTINUOUS" | "CUSTOM";
+  }): Promise<void> {
     throw new Error("setExposureMode not supported under the web platform");
   }
 
-  async getExposureCompensationRange(): Promise<{ min: number; max: number; step: number }> {
-    throw new Error("getExposureCompensationRange not supported under the web platform");
+  async getExposureCompensationRange(): Promise<{
+    min: number;
+    max: number;
+    step: number;
+  }> {
+    throw new Error(
+      "getExposureCompensationRange not supported under the web platform",
+    );
   }
 
   async getExposureCompensation(): Promise<{ value: number }> {
-    throw new Error("getExposureCompensation not supported under the web platform");
+    throw new Error(
+      "getExposureCompensation not supported under the web platform",
+    );
   }
 
   async setExposureCompensation(_options: { value: number }): Promise<void> {
-    throw new Error("setExposureCompensation not supported under the web platform");
+    throw new Error(
+      "setExposureCompensation not supported under the web platform",
+    );
   }
 
   async deleteFile(_options: { path: string }): Promise<{ success: boolean }> {

--- a/src/web.ts
+++ b/src/web.ts
@@ -1203,7 +1203,7 @@ export class CameraPreviewWeb extends WebPlugin implements CameraPreviewPlugin {
   }
 
   // Exposure stubs (unsupported on web)
-  async getExposureModes(): Promise<{ modes: ExposureMode }> {
+  async getExposureModes(): Promise<{ modes: ExposureMode[] }> {
     throw new Error("getExposureModes not supported under the web platform");
   }
 


### PR DESCRIPTION
# Summary
- Adds full **exposure control support** on iOS and Android.  
- Updates the example app UI to test it.  
- Documents the new APIs.  

---

# What’s New

## Exposure Mode APIs
- `getExposureModes()`
- `getExposureMode()` *(replaces `getCurrentExposureMode`)*
- `setExposureMode({ mode: "AUTO" | "LOCK" | "CONTINUOUS" | "CUSTOM" })`

## Exposure Compensation (EV bias) APIs
- `getExposureCompensationRange()` → `{ min, max, step }`
- `getExposureCompensation()`
- `setExposureCompensation({ value })`

---

# iOS
- Default exposure mode set to **CONTINUOUS** on camera start.  
- Switching to **AUTO** or **CONTINUOUS** resets EV to `0`.  
- Exposure point updates on focus/tap only for **AUTO**/**CONTINUOUS**.  
- Uppercase exposure mode strings; step approximated to `0.1`.  

---

# Android
- Implemented with **CameraX + Camera2 interop**:  
  - **LOCK** → `CONTROL_AE_LOCK=true, AE_MODE=ON`  
  - **CONTINUOUS** → `CONTROL_AE_LOCK=false, AE_MODE=ON`  
- Fixed build by using `CaptureRequestOptions` with `setCaptureRequestOptions`.  
- EV resets to `0` on tap-to-focus.  
- EV range/step read from `ExposureState`.  

---

# Example App
- **Camera modal**:  
  - Exposure mode toggle (☀️ icon) cycles modes.  
  - EV readout + `+/-` buttons moved to a **top-right FAB** outside preview.  
  - Buttons disabled at bounds and in **LOCK/CUSTOM**.  
- Service wrappers for all new APIs.  

---

# Documentation
- **README**: Added *“Exposure controls (iOS & Android)”* with examples and platform notes.  

---

# Testing Notes
- Verify **exposure mode cycling** and **EV changes** on iOS and Android.  
- Confirm EV resets on tap to focus
- Example app: check **EV UI placement**, **disabled states**, and **live updates**.  

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Exposure controls on iOS and Android: query/set exposure mode (AUTO/LOCK/CONTINUOUS/CUSTOM) and manage exposure compensation (EV range, current value, adjust by step).

- **Example App**
  - New floating EV controls (cycle modes, increase/decrease EV) with accessibility labels.

- **Web**
  - Exposure API stubs added that explicitly report "not supported" on web.

- **Documentation**
  - README expanded with exposure guide, API docs, TypeScript signatures, and usage examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->