### PR TITLE
fix(ios): fix startRecording method

### DIFF
--- a/ios/Sources/CapgoCameraPreviewPlugin/CameraController.swift
+++ b/ios/Sources/CapgoCameraPreviewPlugin/CameraController.swift
@@ -1450,9 +1450,23 @@ extension CameraController {
             throw CameraControllerError.fileVideoOutputNotFound
         }
 
+        // Ensure the movie file output is attached to the active session.
+        // If the camera was started without cameraMode=true, the output may not have been added yet.
+        if !captureSession.outputs.contains(where: { $0 === fileVideoOutput }) {
+            captureSession.beginConfiguration()
+            if captureSession.canAddOutput(fileVideoOutput) {
+                captureSession.addOutput(fileVideoOutput)
+            } else {
+                captureSession.commitConfiguration()
+                throw CameraControllerError.invalidOperation
+            }
+            captureSession.commitConfiguration()
+        }
+
         // cpcp_video_A6C01203 - portrait
         //
         if let connection = fileVideoOutput.connection(with: .video) {
+            if connection.isEnabled == false { connection.isEnabled = true }
             switch UIDevice.current.orientation {
             case .landscapeRight:
                 connection.videoOrientation = .landscapeLeft

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -508,7 +508,7 @@ export interface CameraPreviewPlugin {
   /**
    * Starts recording a video.
    *
-   * @param {CameraPreviewOptions} options - The options for video recording.
+   * @param {CameraPreviewOptions} options - The options for video recording. Only iOS.
    * @returns {Promise<void>} A promise that resolves when video recording starts.
    * @since 0.0.1
    */


### PR DESCRIPTION
If fileVideoOutput isn’t already in captureSession.outputs, the code now begins a session configuration, adds it when possible, and commits the configuration; otherwise throws a clear error.
Ensures the video connection is enabled before setting videoOrientation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of starting video recording on iOS by ensuring the recording output is correctly attached to the active session and the connection is enabled.
  * More consistent handling of video orientation during recording on iOS, reducing unexpected orientation issues.

* **Documentation**
  * Clarified that startRecordVideo options apply to iOS only, with no changes to the API or behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->