### PR TITLE
fix: prevent NPE by using local future reference in focus listener

### DIFF
--- a/android/src/main/java/com/ahm/capacitor/camera/preview/CameraXView.java
+++ b/android/src/main/java/com/ahm/capacitor/camera/preview/CameraXView.java
@@ -1905,14 +1905,15 @@ public class CameraXView implements LifecycleOwner, LifecycleObserver {
       .build();
 
     try {
-      currentFocusFuture = camera
-        .getCameraControl()
-        .startFocusAndMetering(action);
+      final ListenableFuture<FocusMeteringResult> future = camera
+          .getCameraControl()
+          .startFocusAndMetering(action);
+      currentFocusFuture = future; 
 
-      currentFocusFuture.addListener(
+      future.addListener(
         () -> {
           try {
-            FocusMeteringResult result = currentFocusFuture.get();
+            FocusMeteringResult result = future.get();
           } catch (Exception e) {
             // Handle cancellation gracefully - this is expected when rapid taps occur
             if (
@@ -1920,7 +1921,7 @@ public class CameraXView implements LifecycleOwner, LifecycleObserver {
               (e
                   .getMessage()
                   .contains("Cancelled by another startFocusAndMetering") ||
-                e.getMessage().contains("OperationCanceledException") ||
+              e.getMessage().contains("OperationCanceledException") ||
                 e
                   .getClass()
                   .getSimpleName()
@@ -1934,8 +1935,7 @@ public class CameraXView implements LifecycleOwner, LifecycleObserver {
               Log.e(TAG, "Error during focus: " + e.getMessage());
             }
           } finally {
-            // Clear the reference if this is still the current operation
-            if (currentFocusFuture != null && currentFocusFuture.isDone()) {
+            if (currentFocusFuture == future && currentFocusFuture.isDone()) {
               currentFocusFuture = null;
             }
           }


### PR DESCRIPTION
Capture startFocusAndMetering() future in a final local variable and use it
inside the listener. Only clear currentFocusFuture if it still matches, avoiding
null dereference when rapid taps occur.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improves autofocus reliability during rapid taps, reducing missed focus events.
  * Prevents false error logs when a focus action is intentionally canceled.
  * Lowers the chance of freezes or race-condition glitches during fast interactions.

* **Refactor**
  * Streamlines internal focus operation handling for better concurrency safety.
  * Ensures accurate cleanup of focus state without affecting the public API.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->