### PR TITLE
Update README with Android installation steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,7 @@ In your `ios/App/App/Info.plist`, you must provide descriptions for the permissi
   ```
 
 ## Extra Android installation steps
+### Permissions
 
 **Important** `camera-preview` 3+ requires Gradle 7.
 Open `android/app/src/main/AndroidManifest.xml` and above the closing `</manifest>` tag add this line to request the CAMERA permission:
@@ -226,6 +227,23 @@ Open `android/app/src/main/AndroidManifest.xml` and above the closing `</manifes
 ```
 
 For more help consult the [Capacitor docs](https://capacitorjs.com/docs/android/configuration#configuring-androidmanifestxml).
+
+### opaque WebView
+By default, the Android WebView background is opaque, hiding the video stream running behind it when using option `toBack: true`.
+
+To fix this, override `onCreate` in your `MainActivity.java` and set both the window and the WebView background to transparent:
+
+```java
+@Override
+protected void onCreate(Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+    // Minimal transparency fix
+    getWindow().setBackgroundDrawable(new ColorDrawable(Color.TRANSPARENT));
+    getBridge().getWebView().setBackgroundColor(Color.TRANSPARENT);
+}
+```
+With this change, the camera preview or any background content will correctly show through the WebView.
+
 
 ## Extra iOS installation steps
 

--- a/README.md
+++ b/README.md
@@ -228,18 +228,30 @@ Open `android/app/src/main/AndroidManifest.xml` and above the closing `</manifes
 
 For more help consult the [Capacitor docs](https://capacitorjs.com/docs/android/configuration#configuring-androidmanifestxml).
 
-### opaque WebView
+### Opaque WebView
 By default, the Android WebView background is opaque, hiding the video stream running behind it when using option `toBack: true`.
 
 To fix this, override `onCreate` in your `MainActivity.java` and set both the window and the WebView background to transparent:
 
 ```java
-@Override
-protected void onCreate(Bundle savedInstanceState) {
-    super.onCreate(savedInstanceState);
-    // Minimal transparency fix
-    getWindow().setBackgroundDrawable(new ColorDrawable(Color.TRANSPARENT));
-    getBridge().getWebView().setBackgroundColor(Color.TRANSPARENT);
+// 👇 Add to the top of the file
+import android.os.Bundle;
+import android.graphics.drawable.ColorDrawable;
+import android.graphics.Color;
+
+
+public class MainActivity {
+
+// 👇 Add this 
+  @Override
+  protected void onCreate(Bundle savedInstanceState) {
+      super.onCreate(savedInstanceState);
+  
+      getWindow().setBackgroundDrawable(new ColorDrawable(Color.TRANSPARENT));
+      getBridge().getWebView().setBackgroundColor(Color.TRANSPARENT);
+  }
+
+
 }
 ```
 With this change, the camera preview or any background content will correctly show through the WebView.


### PR DESCRIPTION
While testing the plugin on Android 10, I noticed that the WebView is opaque. I don’t know yet if this also affects versions above or below Android 10, so this pull request might need further validation.

Related issue : #216 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded Android installation instructions with a new Permissions section listing required permissions (camera, audio, storage) and an example snippet.
  * Added guidance for handling opaque Android WebView when running in the background (toBack: true), including steps to make the window and WebView transparent so the camera preview is visible.
  * Documentation only; no code or API changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->