### PR TITLE
feat: add `embedTimestamp` option to overlay capture time on images

### DIFF
--- a/android/src/main/java/app/capgo/capacitor/camera/preview/CameraPreview.java
+++ b/android/src/main/java/app/capgo/capacitor/camera/preview/CameraPreview.java
@@ -369,8 +369,11 @@ public class CameraPreview
     );
     Integer width = call.getInt("width");
     Integer height = call.getInt("height");
+    final boolean embedTimestamp = Boolean.TRUE.equals(
+      call.getBoolean("embedTimestamp")
+    );
 
-    cameraXView.capturePhoto(quality, saveToGallery, width, height, location);
+    cameraXView.capturePhoto(quality, saveToGallery, width, height, location, embedTimestamp);
   }
 
   @PluginMethod

--- a/android/src/main/java/app/capgo/capacitor/camera/preview/CameraPreview.java
+++ b/android/src/main/java/app/capgo/capacitor/camera/preview/CameraPreview.java
@@ -373,7 +373,14 @@ public class CameraPreview
       call.getBoolean("embedTimestamp")
     );
 
-    cameraXView.capturePhoto(quality, saveToGallery, width, height, location, embedTimestamp);
+    cameraXView.capturePhoto(
+      quality,
+      saveToGallery,
+      width,
+      height,
+      location,
+      embedTimestamp
+    );
   }
 
   @PluginMethod

--- a/android/src/main/java/app/capgo/capacitor/camera/preview/CameraXView.java
+++ b/android/src/main/java/app/capgo/capacitor/camera/preview/CameraXView.java
@@ -1183,7 +1183,7 @@ public class CameraXView implements LifecycleOwner, LifecycleObserver {
       ", width: " +
       width +
       ", height: " +
-      height + 
+      height +
       ", saveToGallery: " +
       saveToGallery +
       ", embedTimestamp: " +
@@ -1263,7 +1263,10 @@ public class CameraXView implements LifecycleOwner, LifecycleObserver {
                 height
               );
               if (embedTimestamp) {
-                resizedBitmap = drawTimestampOntoBitmap(resizedBitmap, exifInterface);
+                resizedBitmap = drawTimestampOntoBitmap(
+                  resizedBitmap,
+                  exifInterface
+                );
               }
               ByteArrayOutputStream stream = new ByteArrayOutputStream();
               resizedBitmap.compress(
@@ -1300,7 +1303,10 @@ public class CameraXView implements LifecycleOwner, LifecycleObserver {
               );
               Bitmap previewCropped = cropBitmapToMatchPreview(originalBitmap);
               if (embedTimestamp) {
-                previewCropped = drawTimestampOntoBitmap(previewCropped, exifInterface);
+                previewCropped = drawTimestampOntoBitmap(
+                  previewCropped,
+                  exifInterface
+                );
               }
               ByteArrayOutputStream stream = new ByteArrayOutputStream();
               previewCropped.compress(
@@ -1407,24 +1413,35 @@ public class CameraXView implements LifecycleOwner, LifecycleObserver {
     final String fmt = "yyyy-MM-dd HH:mm:ss";
     String when = null;
     if (exif != null) {
-        final String exifDate = exif.getAttribute(ExifInterface.TAG_DATETIME_ORIGINAL); // "yyyy:MM:dd HH:mm:ss"
-        if (exifDate != null && !exifDate.trim().isEmpty()) {
-            try {
-                java.text.SimpleDateFormat inFmt =
-                        new java.text.SimpleDateFormat("yyyy:MM:dd HH:mm:ss", java.util.Locale.US);
-                java.util.Date d = inFmt.parse(exifDate);
-                if (d != null) {
-                    when = new java.text.SimpleDateFormat(fmt, java.util.Locale.getDefault()).format(d);
-                }
-            } catch (java.text.ParseException ignored) {}
-        }
+      final String exifDate = exif.getAttribute(
+        ExifInterface.TAG_DATETIME_ORIGINAL
+      ); // "yyyy:MM:dd HH:mm:ss"
+      if (exifDate != null && !exifDate.trim().isEmpty()) {
+        try {
+          java.text.SimpleDateFormat inFmt = new java.text.SimpleDateFormat(
+            "yyyy:MM:dd HH:mm:ss",
+            java.util.Locale.US
+          );
+          java.util.Date d = inFmt.parse(exifDate);
+          if (d != null) {
+            when = new java.text.SimpleDateFormat(
+              fmt,
+              java.util.Locale.getDefault()
+            ).format(d);
+          }
+        } catch (java.text.ParseException ignored) {}
+      }
     }
     if (when == null) {
-        when = new java.text.SimpleDateFormat(fmt, java.util.Locale.getDefault())
-                .format(new java.util.Date());
+      when = new java.text.SimpleDateFormat(
+        fmt,
+        java.util.Locale.getDefault()
+      ).format(new java.util.Date());
     }
 
-    final Bitmap bmp = src.isMutable() ? src : src.copy(Bitmap.Config.ARGB_8888, true);
+    final Bitmap bmp = src.isMutable()
+      ? src
+      : src.copy(Bitmap.Config.ARGB_8888, true);
     final Canvas canvas = new Canvas(bmp);
 
     // ---- Match iOS constants ----
@@ -1435,7 +1452,9 @@ public class CameraXView implements LifecycleOwner, LifecycleObserver {
     final float margin = 12f;
 
     // Text paint (SF .semibold ≈ Roboto Medium)
-    final Paint text = new Paint(Paint.ANTI_ALIAS_FLAG | Paint.SUBPIXEL_TEXT_FLAG | Paint.LINEAR_TEXT_FLAG);
+    final Paint text = new Paint(
+      Paint.ANTI_ALIAS_FLAG | Paint.SUBPIXEL_TEXT_FLAG | Paint.LINEAR_TEXT_FLAG
+    );
     text.setColor(Color.WHITE);
     text.setTypeface(Typeface.create("sans-serif-medium", Typeface.NORMAL));
     text.setTextSize(fontPx);
@@ -1448,12 +1467,12 @@ public class CameraXView implements LifecycleOwner, LifecycleObserver {
     final float textHeight = fm.descent - fm.ascent;
 
     // Bubble rect (top-right)
-    final float bgWidth  = textWidth + paddingH * 2f;
+    final float bgWidth = textWidth + paddingH * 2f;
     final float bgHeight = textHeight + paddingV * 2f;
-    final float bgLeft   = Math.max(0, bmp.getWidth()  - bgWidth - margin);
-    final float bgTop    = margin;
-    final float bgRight  = bgLeft + bgWidth;
-    final float bgBottom = bgTop  + bgHeight;
+    final float bgLeft = Math.max(0, bmp.getWidth() - bgWidth - margin);
+    final float bgTop = margin;
+    final float bgRight = bgLeft + bgWidth;
+    final float bgBottom = bgTop + bgHeight;
 
     // Background color: UIColor(white:0.12, alpha:0.22)
     // -> alpha ≈ 0.22*255 ≈ 56, rgb ≈ 0.12*255 ≈ 31
@@ -1466,11 +1485,19 @@ public class CameraXView implements LifecycleOwner, LifecycleObserver {
     bg.setShadowLayer(6f, 0f, 2f, Color.argb(64, 0, 0, 0));
 
     // Draw bubble
-    canvas.drawRoundRect(bgLeft, bgTop, bgRight, bgBottom, cornerRadius, cornerRadius, bg);
+    canvas.drawRoundRect(
+      bgLeft,
+      bgTop,
+      bgRight,
+      bgBottom,
+      cornerRadius,
+      cornerRadius,
+      bg
+    );
 
     // Text origin (like iOS: top-left inside padding)
     final float textX = bgLeft + paddingH;
-    final float textY = bgTop  + paddingV - fm.ascent; // convert top-left to baseline
+    final float textY = bgTop + paddingV - fm.ascent; // convert top-left to baseline
 
     // High-quality rendering akin to iOS flags
     text.setFilterBitmap(true);

--- a/ios/Sources/CapgoCameraPreviewPlugin/CameraController.swift
+++ b/ios/Sources/CapgoCameraPreviewPlugin/CameraController.swift
@@ -1018,15 +1018,15 @@ extension CameraController {
 
         // Bubble rect (top-right)
         let bgSize  = CGSize(width: textSize.width + paddingH * 2,
-                            height: textSize.height + paddingV * 2)
+                             height: textSize.height + paddingV * 2)
         let margin: CGFloat = 12 // distance from edges of the photo
         let bgOrigin = CGPoint(x: size.width - bgSize.width - margin,
-                            y: margin)
+                               y: margin)
         let bgRect = CGRect(origin: bgOrigin, size: bgSize)
 
         // Text origin inside bubble
         let textOrigin = CGPoint(x: bgRect.minX + paddingH,
-                                y: bgRect.minY + paddingV)
+                                 y: bgRect.minY + paddingV)
 
         let format = UIGraphicsImageRendererFormat.default()
         format.scale = scale
@@ -1081,8 +1081,8 @@ extension CameraController {
             raw = extractDateString(from: metadata)
         }
         if raw == nil, let data = photoData,
-        let src = CGImageSourceCreateWithData(data as CFData, nil),
-        let props = CGImageSourceCopyPropertiesAtIndex(src, 0, nil) as? [String: Any] {
+           let src = CGImageSourceCreateWithData(data as CFData, nil),
+           let props = CGImageSourceCopyPropertiesAtIndex(src, 0, nil) as? [String: Any] {
             raw = extractDateString(from: props)
         }
 
@@ -1121,7 +1121,7 @@ extension CameraController {
         let cgSrc = CGImageSourceCreateWithData(srcData as CFData, nil)
         let baseMetadata: [String: Any]
         if let src = cgSrc,
-        let props = CGImageSourceCopyPropertiesAtIndex(src, 0, nil) as? [String: Any] {
+           let props = CGImageSourceCopyPropertiesAtIndex(src, 0, nil) as? [String: Any] {
             var merged = props
             if let explicit = originalMetadata as? [String: Any] {
                 for (k, v) in explicit { merged[k] = v }

--- a/ios/Sources/CapgoCameraPreviewPlugin/CameraController.swift
+++ b/ios/Sources/CapgoCameraPreviewPlugin/CameraController.swift
@@ -1,6 +1,7 @@
 import AVFoundation
 import UIKit
 import CoreLocation
+import UniformTypeIdentifiers
 
 class CameraController: NSObject {
     private func getVideoOrientation() -> AVCaptureVideoOrientation {
@@ -976,17 +977,9 @@ extension CameraController {
             if embedTimestamp {
                 let when = self.makeTimestampString(from: photoData, metadata: metadata)
                 finalImage = self.drawTimestamp(text: when, on: finalImage)
-
-                let jpegQuality = CGFloat(max(0.0, min(1.0, quality)))
-                let finalJPEG = self.jpegDataPreservingMetadata(from: finalImage,
-                                                                originalPhotoData: photoData,
-                                                                originalMetadata: metadata,
-                                                                quality: jpegQuality)
-                completion(finalImage, finalJPEG, metadata, nil)
-            } else {
-                // Preserve existing behaviour (return original JPEG data)
-                completion(finalImage, photoData, metadata, nil)
             }
+
+            completion(finalImage, photoData, metadata, nil)
 
             // End capture lifecycle
             self.isCapturingPhoto = false

--- a/ios/Sources/CapgoCameraPreviewPlugin/CameraController.swift
+++ b/ios/Sources/CapgoCameraPreviewPlugin/CameraController.swift
@@ -888,7 +888,7 @@ extension CameraController {
         self.updateVideoOrientation()
     }
 
-    func captureImage(width: Int?, height: Int?, quality: Float, gpsLocation: CLLocation?, completion: @escaping (UIImage?, Data?, [AnyHashable: Any]?, Error?) -> Void) {
+    func captureImage(width: Int?, height: Int?, quality: Float, gpsLocation: CLLocation?, embedTimestamp: Bool, completion: @escaping (UIImage?, Data?, [AnyHashable: Any]?, Error?) -> Void) {
         guard let photoOutput = self.photoOutput else {
             completion(nil, nil, nil, NSError(domain: "Camera", code: 0, userInfo: [NSLocalizedDescriptionKey: "Photo output is not available"]))
             return
@@ -972,7 +972,22 @@ extension CameraController {
                 print("[CameraPreview] Applied aspect ratio cropping for \(aspectRatio): \(finalImage.size.width)x\(finalImage.size.height)")
             }
 
-            completion(finalImage, photoData, metadata, nil)
+            // Embed timestamp if requested
+            if embedTimestamp {
+                let when = self.makeTimestampString(from: photoData, metadata: metadata)
+                finalImage = self.drawTimestamp(text: when, on: finalImage)
+
+                let jpegQuality = CGFloat(max(0.0, min(1.0, quality)))
+                let finalJPEG = self.jpegDataPreservingMetadata(from: finalImage,
+                                                                originalPhotoData: photoData,
+                                                                originalMetadata: metadata,
+                                                                quality: jpegQuality)
+                completion(finalImage, finalJPEG, metadata, nil)
+            } else {
+                // Preserve existing behaviour (return original JPEG data)
+                completion(finalImage, photoData, metadata, nil)
+            }
+
             // End capture lifecycle
             self.isCapturingPhoto = false
             if self.stopRequestedAfterCapture {
@@ -981,6 +996,180 @@ extension CameraController {
         }
 
         photoOutput.capturePhoto(with: settings, delegate: self)
+    }
+
+    /// Draws a timestamp bubble at the top-right of the image and returns a new image.
+    func drawTimestamp(text: String, on image: UIImage) -> UIImage {
+        let textColor: UIColor = .white
+        // Slightly lighter/clearer than before (matches iOS feel better)
+        let backgroundColor: UIColor = UIColor(white: 0.12, alpha: 0.22)
+        let paddingH: CGFloat = 16    // horizontal
+        let paddingV: CGFloat = 10    // vertical
+        let cornerRadius: CGFloat = 10
+        let drawsShadow = true
+
+        let base = image.fixedOrientation() ?? image
+        let scale = base.scale
+        let size  = base.size
+
+        // ≈3.5% of image width (clamped to ≥10pt)
+        let fontPointSize: CGFloat = max(10, size.width * 0.035)
+        // San Francisco system font is what the Camera/Photos overlays use
+        let font: UIFont = .systemFont(ofSize: fontPointSize, weight: .semibold)
+
+        let attrs: [NSAttributedString.Key: Any] = [
+            .font: font,
+            .foregroundColor: textColor
+        ]
+        let textSize = (text as NSString).size(withAttributes: attrs)
+
+        // Bubble rect (top-right)
+        let bgSize  = CGSize(width: textSize.width + paddingH * 2,
+                            height: textSize.height + paddingV * 2)
+        let margin: CGFloat = 12 // distance from edges of the photo
+        let bgOrigin = CGPoint(x: size.width - bgSize.width - margin,
+                            y: margin)
+        let bgRect = CGRect(origin: bgOrigin, size: bgSize)
+
+        // Text origin inside bubble
+        let textOrigin = CGPoint(x: bgRect.minX + paddingH,
+                                y: bgRect.minY + paddingV)
+
+        let format = UIGraphicsImageRendererFormat.default()
+        format.scale = scale
+        format.opaque = true
+
+        return UIGraphicsImageRenderer(size: size, format: format).image { ctx in
+            base.draw(in: CGRect(origin: .zero, size: size))
+
+            // Bubble
+            let bubblePath = UIBezierPath(roundedRect: bgRect, cornerRadius: cornerRadius)
+            if drawsShadow {
+                ctx.cgContext.saveGState()
+                ctx.cgContext.setShadow(offset: CGSize(width: 0, height: 2),
+                                        blur: 6,
+                                        color: UIColor.black.withAlphaComponent(0.25).cgColor)
+                backgroundColor.setFill()
+                bubblePath.fill()
+                ctx.cgContext.restoreGState()
+            } else {
+                backgroundColor.setFill()
+                bubblePath.fill()
+            }
+
+            // High-quality text rendering
+            let g = ctx.cgContext
+            g.setAllowsAntialiasing(true)
+            g.setShouldAntialias(true)
+            g.setAllowsFontSmoothing(true)
+            g.setShouldSmoothFonts(true)
+            g.setShouldSubpixelPositionFonts(true)
+            g.interpolationQuality = .high
+
+            // Single pass: fill only (no stroke/outline)
+            (text as NSString).draw(at: textOrigin, withAttributes: attrs)
+        }
+    }
+
+    func makeTimestampString(from photoData: Data?, metadata: [AnyHashable: Any]?) -> String {
+        // Try metadata first (fast path)
+        func extractDateString(from meta: [AnyHashable: Any]) -> String? {
+            if let exif = meta[kCGImagePropertyExifDictionary as String] as? [String: Any] {
+                if let s = exif[kCGImagePropertyExifDateTimeOriginal as String] as? String { return s }        // "yyyy:MM:dd HH:mm:ss"
+                if let s = exif[kCGImagePropertyExifDateTimeDigitized as String] as? String { return s }
+            }
+            if let tiff = meta[kCGImagePropertyTIFFDictionary as String] as? [String: Any] {
+                if let s = tiff[kCGImagePropertyTIFFDateTime as String] as? String { return s }                // "yyyy:MM:dd HH:mm:ss"
+            }
+            return nil
+        }
+
+        var raw: String?
+        if let metadata = metadata as? [String: Any] {
+            raw = extractDateString(from: metadata)
+        }
+
+        // If not in metadata, try reading from the JPEG data’s properties
+        if raw == nil, let data = photoData,
+        let src = CGImageSourceCreateWithData(data as CFData, nil),
+        let props = CGImageSourceCopyPropertiesAtIndex(src, 0, nil) as? [String: Any] {
+            raw = extractDateString(from: props)
+        }
+
+        // Parse EXIF formatted date "yyyy:MM:dd HH:mm:ss" (optionally with .SSS)
+        let outFmt = DateFormatter()
+        outFmt.locale = .current
+        outFmt.timeZone = .current
+        outFmt.dateFormat = "yyyy-MM-dd HH:mm:ss"
+
+        if let raw = raw {
+            let candidates = ["yyyy:MM:dd HH:mm:ss.SSS", "yyyy:MM:dd HH:mm:ss"]
+            for fmt in candidates {
+                let df = DateFormatter()
+                df.locale = Locale(identifier: "en_US_POSIX")
+                df.timeZone = TimeZone(secondsFromGMT: 0) // EXIF is effectively local/unknown; using GMT avoids DST parse issues
+                df.dateFormat = fmt
+                if let d = df.date(from: raw) {
+                    return outFmt.string(from: d)
+                }
+            }
+        }
+
+        // Fallback: now
+        return outFmt.string(from: Date())
+    }
+
+    // Create JPEG data from `image`, merging the original EXIF/GPS/etc. and forcing Orientation=1.
+    func jpegDataPreservingMetadata(from image: UIImage,
+                                    originalPhotoData: Data?,
+                                    originalMetadata: [AnyHashable: Any]?,
+                                    quality: CGFloat = 0.9) -> Data? {
+        // Encode pixels first
+        guard let cgImg = image.cgImage else { return image.jpegData(compressionQuality: quality) }
+        let uiImageData = UIImage(cgImage: cgImg, scale: image.scale, orientation: .up)
+            .jpegData(compressionQuality: quality)
+
+        // If we don’t have source metadata, just return the new JPEG
+        guard let srcData = originalPhotoData, let newJPEG = uiImageData else { return uiImageData }
+
+        // Load base metadata from source, then overlay any explicit metadata dict we were given
+        let cgSrc = CGImageSourceCreateWithData(srcData as CFData, nil)
+        let baseMetadata: [String: Any]
+        if let src = cgSrc,
+        let props = CGImageSourceCopyPropertiesAtIndex(src, 0, nil) as? [String: Any] {
+            var merged = props
+            if let explicit = originalMetadata as? [String: Any] {
+                for (k, v) in explicit { merged[k] = v }
+            }
+            baseMetadata = merged
+        } else if let explicit = originalMetadata as? [String: Any] {
+            baseMetadata = explicit
+        } else {
+            return newJPEG
+        }
+
+        // Prepare destination
+        let dstData = NSMutableData()
+        guard let cgDst = CGImageDestinationCreateWithData(dstData, UTType.jpeg.identifier as CFString, 1, nil) else {
+            return newJPEG
+        }
+
+        // Force normalized orientation (pixels are already .up)
+        var metaOut = baseMetadata
+        if var tiff = metaOut[kCGImagePropertyTIFFDictionary as String] as? [String: Any] {
+            tiff[kCGImagePropertyTIFFOrientation as String] = 1
+            metaOut[kCGImagePropertyTIFFDictionary as String] = tiff
+        }
+        metaOut[kCGImagePropertyOrientation as String] = 1
+
+        // Write the new pixels + merged metadata
+        if let cgImage = UIImage(data: newJPEG)?.cgImage {
+            CGImageDestinationAddImage(cgDst, cgImage, metaOut as CFDictionary)
+            CGImageDestinationFinalize(cgDst)
+            return (dstData as Data)
+        }
+
+        return newJPEG
     }
 
     func addGPSMetadata(to image: UIImage, location: CLLocation) {

--- a/ios/Sources/CapgoCameraPreviewPlugin/Plugin.swift
+++ b/ios/Sources/CapgoCameraPreviewPlugin/Plugin.swift
@@ -855,12 +855,13 @@ public class CameraPreview: CAPPlugin, CAPBridgedPlugin, CLLocationManagerDelega
         let quality = call.getFloat("quality", 85)
         let saveToGallery = call.getBool("saveToGallery", false)
         let withExifLocation = call.getBool("withExifLocation", false)
+        let embedTimestamp = call.getBool("embedTimestamp", false) ?? false
         let width = call.getInt("width")
         let height = call.getInt("height")
 
         print("[CameraPreview] Raw parameter values - width: \(String(describing: width)), height: \(String(describing: height))")
 
-        print("[CameraPreview] Capture params - quality: \(quality), saveToGallery: \(saveToGallery), withExifLocation: \(withExifLocation), width: \(width ?? -1), height: \(height ?? -1)")
+        print("[CameraPreview] Capture params - quality: \(quality), saveToGallery: \(saveToGallery), withExifLocation: \(withExifLocation), embedTimestamp: \(embedTimestamp), width: \(width ?? -1), height: \(height ?? -1)")
         print("[CameraPreview] Current location: \(self.currentLocation?.description ?? "nil")")
         // Safely read frame from main thread for logging
         let (previewWidth, previewHeight): (CGFloat, CGFloat) = {
@@ -877,7 +878,7 @@ public class CameraPreview: CAPPlugin, CAPBridgedPlugin, CLLocationManagerDelega
         }()
         print("[CameraPreview] Preview dimensions: \(previewWidth)x\(previewHeight)")
 
-        self.cameraController.captureImage(width: width, height: height, quality: quality, gpsLocation: self.currentLocation) { (image, originalPhotoData, _, error) in
+        self.cameraController.captureImage(width: width, height: height, quality: quality, gpsLocation: self.currentLocation, embedTimestamp: embedTimestamp) { (image, originalPhotoData, _, error) in
             print("[CameraPreview] captureImage callback received")
             DispatchQueue.main.async {
                 print("[CameraPreview] Processing capture on main thread")

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -249,6 +249,12 @@ export interface CameraPreviewPictureOptions {
    * @since 7.6.0
    */
   withExifLocation?: boolean;
+  /**
+   * If true, the plugin will embed a timestamp in the top-right corner of the image.
+   * @default false
+   * @since 7.17.0
+   */
+  embedTimestamp?: boolean;
 }
 
 /** Represents EXIF data extracted from an image. */

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -1,21 +1,21 @@
-import type { PluginListenerHandle } from '@capacitor/core';
+import type { PluginListenerHandle } from "@capacitor/core";
 
-export type CameraPosition = 'rear' | 'front';
+export type CameraPosition = "rear" | "front";
 
 export type FlashMode = CameraPreviewFlashMode;
 
-export type GridMode = 'none' | '3x3' | '4x4';
+export type GridMode = "none" | "3x3" | "4x4";
 
-export type CameraPositioning = 'center' | 'top' | 'bottom';
+export type CameraPositioning = "center" | "top" | "bottom";
 
 export enum DeviceType {
-  ULTRA_WIDE = 'ultraWide',
-  WIDE_ANGLE = 'wideAngle',
-  TELEPHOTO = 'telephoto',
-  TRUE_DEPTH = 'trueDepth',
-  DUAL = 'dual',
-  DUAL_WIDE = 'dualWide',
-  TRIPLE = 'triple',
+  ULTRA_WIDE = "ultraWide",
+  WIDE_ANGLE = "wideAngle",
+  TELEPHOTO = "telephoto",
+  TRUE_DEPTH = "trueDepth",
+  DUAL = "dual",
+  DUAL_WIDE = "dualWide",
+  TRIPLE = "triple",
 }
 
 /**
@@ -111,7 +111,7 @@ export interface CameraPreviewOptions {
    *
    * @since 2.0.0
    */
-  aspectRatio?: '4:3' | '16:9';
+  aspectRatio?: "4:3" | "16:9";
   /**
    * The grid overlay to display on the camera preview.
    * @default "none"
@@ -249,12 +249,6 @@ export interface CameraPreviewPictureOptions {
    * @since 7.6.0
    */
   withExifLocation?: boolean;
-  /**
-   * If true, the plugin will embed a timestamp in the top-right corner of the image.
-   * @default false
-   * @since 7.17.0
-   */
-  embedTimestamp?: boolean;
 }
 
 /** Represents EXIF data extracted from an image. */
@@ -262,7 +256,7 @@ export interface ExifData {
   [key: string]: any;
 }
 
-export type PictureFormat = 'jpeg' | 'png';
+export type PictureFormat = "jpeg" | "png";
 
 /** Defines a standard picture size with width and height. */
 export interface PictureSize {
@@ -295,10 +289,10 @@ export interface CameraSampleOptions {
  * The available flash modes for the camera.
  * 'torch' is a continuous light mode.
  */
-export type CameraPreviewFlashMode = 'off' | 'on' | 'auto' | 'torch';
+export type CameraPreviewFlashMode = "off" | "on" | "auto" | "torch";
 
 /** Reusable exposure mode type for cross-platform support. */
-export type ExposureMode = 'AUTO' | 'LOCK' | 'CONTINUOUS' | 'CUSTOM';
+export type ExposureMode = "AUTO" | "LOCK" | "CONTINUOUS" | "CUSTOM";
 
 /**
  * Defines the options for setting the camera preview's opacity.
@@ -331,7 +325,12 @@ export interface SafeAreaInsets {
 /**
  * Canonical device orientation values across platforms.
  */
-export type DeviceOrientation = 'portrait' | 'landscape-left' | 'landscape-right' | 'portrait-upside-down' | 'unknown';
+export type DeviceOrientation =
+  | "portrait"
+  | "landscape-left"
+  | "landscape-right"
+  | "portrait-upside-down"
+  | "unknown";
 
 /**
  * The main interface for the CameraPreview plugin.
@@ -375,7 +374,9 @@ export interface CameraPreviewPlugin {
    *   - `exif`: extracted EXIF metadata when available
    * @since 0.0.1
    */
-  capture(options: CameraPreviewPictureOptions): Promise<{ value: string; exif: ExifData }>;
+  capture(
+    options: CameraPreviewPictureOptions,
+  ): Promise<{ value: string; exif: ExifData }>;
 
   /**
    * Captures a single frame from the camera preview stream.
@@ -407,7 +408,11 @@ export interface CameraPreviewPlugin {
    * @since 7.5.0
    * @platform android, ios
    */
-  setAspectRatio(options: { aspectRatio: '4:3' | '16:9'; x?: number; y?: number }): Promise<{
+  setAspectRatio(options: {
+    aspectRatio: "4:3" | "16:9";
+    x?: number;
+    y?: number;
+  }): Promise<{
     width: number;
     height: number;
     x: number;
@@ -421,7 +426,7 @@ export interface CameraPreviewPlugin {
    * @since 7.5.0
    * @platform android, ios
    */
-  getAspectRatio(): Promise<{ aspectRatio: '4:3' | '16:9' }>;
+  getAspectRatio(): Promise<{ aspectRatio: "4:3" | "16:9" }>;
 
   /**
    * Sets the grid mode of the camera preview overlay.
@@ -468,7 +473,9 @@ export interface CameraPreviewPlugin {
    * @returns {Promise<void>} A promise that resolves when the flash mode is set.
    * @since 0.0.1
    */
-  setFlashMode(options: { flashMode: CameraPreviewFlashMode | string }): Promise<void>;
+  setFlashMode(options: {
+    flashMode: CameraPreviewFlashMode | string;
+  }): Promise<void>;
 
   /**
    * Toggles between the front and rear cameras.
@@ -553,7 +560,11 @@ export interface CameraPreviewPlugin {
    * @since 7.5.0
    * @platform android, ios
    */
-  setZoom(options: { level: number; ramp?: boolean; autoFocus?: boolean }): Promise<void>;
+  setZoom(options: {
+    level: number;
+    ramp?: boolean;
+    autoFocus?: boolean;
+  }): Promise<void>;
 
   /**
    * Gets the current flash mode.
@@ -610,7 +621,12 @@ export interface CameraPreviewPlugin {
    * @since 7.5.0
    * @platform android, ios
    */
-  setPreviewSize(options: { x?: number; y?: number; width: number; height: number }): Promise<{
+  setPreviewSize(options: {
+    x?: number;
+    y?: number;
+    width: number;
+    height: number;
+  }): Promise<{
     width: number;
     height: number;
     x: number;
@@ -641,8 +657,13 @@ export interface CameraPreviewPlugin {
    * @platform android, ios
    */
   addListener(
-    eventName: 'screenResize',
-    listenerFunc: (data: { width: number; height: number; x: number; y: number }) => void,
+    eventName: "screenResize",
+    listenerFunc: (data: {
+      width: number;
+      height: number;
+      x: number;
+      y: number;
+    }) => void,
   ): Promise<PluginListenerHandle>;
 
   /**
@@ -654,7 +675,7 @@ export interface CameraPreviewPlugin {
    * @platform android, ios
    */
   addListener(
-    eventName: 'orientationChange',
+    eventName: "orientationChange",
     listenerFunc: (data: { orientation: DeviceOrientation }) => void,
   ): Promise<PluginListenerHandle>;
   /**

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -1,21 +1,21 @@
-import type { PluginListenerHandle } from "@capacitor/core";
+import type { PluginListenerHandle } from '@capacitor/core';
 
-export type CameraPosition = "rear" | "front";
+export type CameraPosition = 'rear' | 'front';
 
 export type FlashMode = CameraPreviewFlashMode;
 
-export type GridMode = "none" | "3x3" | "4x4";
+export type GridMode = 'none' | '3x3' | '4x4';
 
-export type CameraPositioning = "center" | "top" | "bottom";
+export type CameraPositioning = 'center' | 'top' | 'bottom';
 
 export enum DeviceType {
-  ULTRA_WIDE = "ultraWide",
-  WIDE_ANGLE = "wideAngle",
-  TELEPHOTO = "telephoto",
-  TRUE_DEPTH = "trueDepth",
-  DUAL = "dual",
-  DUAL_WIDE = "dualWide",
-  TRIPLE = "triple",
+  ULTRA_WIDE = 'ultraWide',
+  WIDE_ANGLE = 'wideAngle',
+  TELEPHOTO = 'telephoto',
+  TRUE_DEPTH = 'trueDepth',
+  DUAL = 'dual',
+  DUAL_WIDE = 'dualWide',
+  TRIPLE = 'triple',
 }
 
 /**
@@ -111,7 +111,7 @@ export interface CameraPreviewOptions {
    *
    * @since 2.0.0
    */
-  aspectRatio?: "4:3" | "16:9";
+  aspectRatio?: '4:3' | '16:9';
   /**
    * The grid overlay to display on the camera preview.
    * @default "none"
@@ -249,6 +249,12 @@ export interface CameraPreviewPictureOptions {
    * @since 7.6.0
    */
   withExifLocation?: boolean;
+  /**
+   * If true, the plugin will embed a timestamp in the top-right corner of the image.
+   * @default false
+   * @since 7.17.0
+   */
+  embedTimestamp?: boolean;
 }
 
 /** Represents EXIF data extracted from an image. */
@@ -256,7 +262,7 @@ export interface ExifData {
   [key: string]: any;
 }
 
-export type PictureFormat = "jpeg" | "png";
+export type PictureFormat = 'jpeg' | 'png';
 
 /** Defines a standard picture size with width and height. */
 export interface PictureSize {
@@ -289,10 +295,10 @@ export interface CameraSampleOptions {
  * The available flash modes for the camera.
  * 'torch' is a continuous light mode.
  */
-export type CameraPreviewFlashMode = "off" | "on" | "auto" | "torch";
+export type CameraPreviewFlashMode = 'off' | 'on' | 'auto' | 'torch';
 
 /** Reusable exposure mode type for cross-platform support. */
-export type ExposureMode = "AUTO" | "LOCK" | "CONTINUOUS" | "CUSTOM";
+export type ExposureMode = 'AUTO' | 'LOCK' | 'CONTINUOUS' | 'CUSTOM';
 
 /**
  * Defines the options for setting the camera preview's opacity.
@@ -325,12 +331,7 @@ export interface SafeAreaInsets {
 /**
  * Canonical device orientation values across platforms.
  */
-export type DeviceOrientation =
-  | "portrait"
-  | "landscape-left"
-  | "landscape-right"
-  | "portrait-upside-down"
-  | "unknown";
+export type DeviceOrientation = 'portrait' | 'landscape-left' | 'landscape-right' | 'portrait-upside-down' | 'unknown';
 
 /**
  * The main interface for the CameraPreview plugin.
@@ -374,9 +375,7 @@ export interface CameraPreviewPlugin {
    *   - `exif`: extracted EXIF metadata when available
    * @since 0.0.1
    */
-  capture(
-    options: CameraPreviewPictureOptions,
-  ): Promise<{ value: string; exif: ExifData }>;
+  capture(options: CameraPreviewPictureOptions): Promise<{ value: string; exif: ExifData }>;
 
   /**
    * Captures a single frame from the camera preview stream.
@@ -408,11 +407,7 @@ export interface CameraPreviewPlugin {
    * @since 7.5.0
    * @platform android, ios
    */
-  setAspectRatio(options: {
-    aspectRatio: "4:3" | "16:9";
-    x?: number;
-    y?: number;
-  }): Promise<{
+  setAspectRatio(options: { aspectRatio: '4:3' | '16:9'; x?: number; y?: number }): Promise<{
     width: number;
     height: number;
     x: number;
@@ -426,7 +421,7 @@ export interface CameraPreviewPlugin {
    * @since 7.5.0
    * @platform android, ios
    */
-  getAspectRatio(): Promise<{ aspectRatio: "4:3" | "16:9" }>;
+  getAspectRatio(): Promise<{ aspectRatio: '4:3' | '16:9' }>;
 
   /**
    * Sets the grid mode of the camera preview overlay.
@@ -473,9 +468,7 @@ export interface CameraPreviewPlugin {
    * @returns {Promise<void>} A promise that resolves when the flash mode is set.
    * @since 0.0.1
    */
-  setFlashMode(options: {
-    flashMode: CameraPreviewFlashMode | string;
-  }): Promise<void>;
+  setFlashMode(options: { flashMode: CameraPreviewFlashMode | string }): Promise<void>;
 
   /**
    * Toggles between the front and rear cameras.
@@ -560,11 +553,7 @@ export interface CameraPreviewPlugin {
    * @since 7.5.0
    * @platform android, ios
    */
-  setZoom(options: {
-    level: number;
-    ramp?: boolean;
-    autoFocus?: boolean;
-  }): Promise<void>;
+  setZoom(options: { level: number; ramp?: boolean; autoFocus?: boolean }): Promise<void>;
 
   /**
    * Gets the current flash mode.
@@ -621,12 +610,7 @@ export interface CameraPreviewPlugin {
    * @since 7.5.0
    * @platform android, ios
    */
-  setPreviewSize(options: {
-    x?: number;
-    y?: number;
-    width: number;
-    height: number;
-  }): Promise<{
+  setPreviewSize(options: { x?: number; y?: number; width: number; height: number }): Promise<{
     width: number;
     height: number;
     x: number;
@@ -657,13 +641,8 @@ export interface CameraPreviewPlugin {
    * @platform android, ios
    */
   addListener(
-    eventName: "screenResize",
-    listenerFunc: (data: {
-      width: number;
-      height: number;
-      x: number;
-      y: number;
-    }) => void,
+    eventName: 'screenResize',
+    listenerFunc: (data: { width: number; height: number; x: number; y: number }) => void,
   ): Promise<PluginListenerHandle>;
 
   /**
@@ -675,7 +654,7 @@ export interface CameraPreviewPlugin {
    * @platform android, ios
    */
   addListener(
-    eventName: "orientationChange",
+    eventName: 'orientationChange',
     listenerFunc: (data: { orientation: DeviceOrientation }) => void,
   ): Promise<PluginListenerHandle>;
   /**


### PR DESCRIPTION
Introduces a new `embedTimestamp` boolean (default: false) that, when enabled, draws a timestamp in the top-right corner of the captured image.

## iOS
![ios](https://github.com/user-attachments/assets/f7b15874-7c1d-4ab9-b906-cafa41175915)
# Android
![android](https://github.com/user-attachments/assets/794dc711-5903-4d42-bc5e-3a2349bb815c)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an optional embedTimestamp flag to photo capture options (off by default).
  - When enabled, a readable timestamp badge is drawn at the top-right of captured images, using EXIF/TIFF time when available or current time as fallback.
  - Applies to resized and cropped outputs; metadata and existing capture behavior are preserved.
  - Supported on iOS and Android.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->