### PR TITLE
feat: add `embedLocation` option to overlay capture time on images

### DIFF
--- a/README.md
+++ b/README.md
@@ -1037,6 +1037,7 @@ Defines the options for capturing a picture.
 | **`saveToGallery`**    | <code>boolean</code>                                    | If true, the captured image will be saved to the user's gallery.                                                                                                                                            | <code>false</code>  | 7.5.0  |
 | **`withExifLocation`** | <code>boolean</code>                                    | If true, the plugin will attempt to add GPS location data to the image's EXIF metadata. This may prompt the user for location permissions.                                                                  | <code>false</code>  | 7.6.0  |
 | **`embedTimestamp`**   | <code>boolean</code>                                    | If true, the plugin will embed a timestamp in the top-right corner of the image.                                                                                                                            | <code>false</code>  | 7.17.0 |
+| **`embedLocation`**    | <code>boolean</code>                                    | If true, the plugin will embed the current location in the top-right corner of the image. Requires `withExifLocation` to be enabled.                                                                        | <code>false</code>  | 7.18.0 |
 
 
 #### CameraSampleOptions

--- a/android/src/main/java/app/capgo/capacitor/camera/preview/CameraPreview.java
+++ b/android/src/main/java/app/capgo/capacitor/camera/preview/CameraPreview.java
@@ -372,6 +372,9 @@ public class CameraPreview
     final boolean embedTimestamp = Boolean.TRUE.equals(
       call.getBoolean("embedTimestamp")
     );
+    final boolean embedLocation = Boolean.TRUE.equals(
+      call.getBoolean("embedLocation")
+    );
 
     cameraXView.capturePhoto(
       quality,
@@ -379,7 +382,8 @@ public class CameraPreview
       width,
       height,
       location,
-      embedTimestamp
+      embedTimestamp,
+      embedLocation
     );
   }
 

--- a/example-app/ios/App/App/Info.plist
+++ b/example-app/ios/App/App/Info.plist
@@ -24,10 +24,12 @@
 	<true/>
 	<key>NSCameraUsageDescription</key>
 	<string>To be able to scan documents</string>
+	<key>NSLocationWhenInUseUsageDescription</key>
+	<string>To be able to save images with GPS location</string>
 	<key>NSMicrophoneUsageDescription</key>
 	<string>To be able to scan documents</string>
-	<key>UILaunchStoryboardName</key>
-	<string>LaunchScreen</string>
+	<key>NSPhotoLibraryUsageDescription</key>
+	<string>To be able to save images to the photo library</string>
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>
@@ -45,6 +47,8 @@
 			</array>
 		</dict>
 	</dict>
+	<key>UILaunchStoryboardName</key>
+	<string>LaunchScreen</string>
 	<key>UIRequiredDeviceCapabilities</key>
 	<array>
 		<string>armv7</string>
@@ -64,9 +68,5 @@
 	</array>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<true/>
-	<key>NSPhotoLibraryUsageDescription</key>
-	<string>To be able to save images to the photo library</string>
-	<key>NSLocationWhenInUseUsageDescription</key>
-	<string>To be able to save images with GPS location</string>
 </dict>
 </plist>

--- a/example-app/src/app/components/camera-modal/camera-modal.component.ts
+++ b/example-app/src/app/components/camera-modal/camera-modal.component.ts
@@ -478,6 +478,7 @@ export class CameraModalComponent implements OnInit, OnDestroy {
         quality,
         saveToGallery: this.saveToGallery(),
         withExifLocation: this.withExifLocation(),
+        embedLocation: this.withExifLocation(),
       };
       if (format === 'png') {
         captureOptions = { ...captureOptions, ...{ format } };

--- a/ios/Sources/CapgoCameraPreviewPlugin/CameraController.swift
+++ b/ios/Sources/CapgoCameraPreviewPlugin/CameraController.swift
@@ -983,7 +983,7 @@ extension CameraController {
                     ? self.makeLocationString(from: gpsLocation, photoData: photoData, metadata: metadata)
                     : nil
 
-                if (when?.isEmpty != false) && (whereStr?.isEmpty != false) {
+                if (when?.isEmpty ?? true) && (whereStr?.isEmpty ?? true) {
                     // Nothing to draw (e.g., embedLocation=true but no GPS present) → skip
                 } else {
                     finalImage = self.drawTimestampAndLocation(on: finalImage, when: when, where: whereStr)

--- a/ios/Sources/CapgoCameraPreviewPlugin/Plugin.swift
+++ b/ios/Sources/CapgoCameraPreviewPlugin/Plugin.swift
@@ -856,13 +856,14 @@ public class CameraPreview: CAPPlugin, CAPBridgedPlugin, CLLocationManagerDelega
         let saveToGallery = call.getBool("saveToGallery", false)
         let withExifLocation = call.getBool("withExifLocation", false)
         let embedTimestamp = call.getBool("embedTimestamp", false) ?? false
-        let embedLocation = call.getBool("embedLocation", false) ?? false
+        let embedLocationRequested = call.getBool("embedLocation", false) ?? false
+        let effectiveEmbedLocation = (withExifLocation ?? false) && embedLocationRequested
         let width = call.getInt("width")
         let height = call.getInt("height")
 
         print("[CameraPreview] Raw parameter values - width: \(String(describing: width)), height: \(String(describing: height))")
 
-        print("[CameraPreview] Capture params - quality: \(quality), saveToGallery: \(saveToGallery), withExifLocation: \(withExifLocation), embedTimestamp: \(embedTimestamp), embedLocation: \(embedLocation), width: \(width ?? -1), height: \(height ?? -1)")
+        print("[CameraPreview] Capture params - quality: \(quality), saveToGallery: \(saveToGallery), withExifLocation: \(withExifLocation ?? false), embedTimestamp: \(embedTimestamp), embedLocation: \(effectiveEmbedLocation) (requested=\(embedLocationRequested)), width: \(width ?? -1), height: \(height ?? -1)")
         print("[CameraPreview] Current location: \(self.currentLocation?.description ?? "nil")")
         // Safely read frame from main thread for logging
         let (previewWidth, previewHeight): (CGFloat, CGFloat) = {
@@ -879,7 +880,8 @@ public class CameraPreview: CAPPlugin, CAPBridgedPlugin, CLLocationManagerDelega
         }()
         print("[CameraPreview] Preview dimensions: \(previewWidth)x\(previewHeight)")
 
-        self.cameraController.captureImage(width: width, height: height, quality: quality, gpsLocation: self.currentLocation, embedTimestamp: embedTimestamp, embedLocation: embedLocation) { (image, originalPhotoData, _, error) in
+        let gpsForThisCapture = (withExifLocation ?? false) ? self.currentLocation : nil
+        self.cameraController.captureImage(width: width, height: height, quality: quality, gpsLocation: gpsForThisCapture, embedTimestamp: embedTimestamp, embedLocation: effectiveEmbedLocation) { (image, originalPhotoData, _, error) in
             print("[CameraPreview] captureImage callback received")
             DispatchQueue.main.async {
                 print("[CameraPreview] Processing capture on main thread")

--- a/ios/Sources/CapgoCameraPreviewPlugin/Plugin.swift
+++ b/ios/Sources/CapgoCameraPreviewPlugin/Plugin.swift
@@ -856,12 +856,13 @@ public class CameraPreview: CAPPlugin, CAPBridgedPlugin, CLLocationManagerDelega
         let saveToGallery = call.getBool("saveToGallery", false)
         let withExifLocation = call.getBool("withExifLocation", false)
         let embedTimestamp = call.getBool("embedTimestamp", false) ?? false
+        let embedLocation = call.getBool("embedLocation", false) ?? false
         let width = call.getInt("width")
         let height = call.getInt("height")
 
         print("[CameraPreview] Raw parameter values - width: \(String(describing: width)), height: \(String(describing: height))")
 
-        print("[CameraPreview] Capture params - quality: \(quality), saveToGallery: \(saveToGallery), withExifLocation: \(withExifLocation), embedTimestamp: \(embedTimestamp), width: \(width ?? -1), height: \(height ?? -1)")
+        print("[CameraPreview] Capture params - quality: \(quality), saveToGallery: \(saveToGallery), withExifLocation: \(withExifLocation), embedTimestamp: \(embedTimestamp), embedLocation: \(embedLocation), width: \(width ?? -1), height: \(height ?? -1)")
         print("[CameraPreview] Current location: \(self.currentLocation?.description ?? "nil")")
         // Safely read frame from main thread for logging
         let (previewWidth, previewHeight): (CGFloat, CGFloat) = {
@@ -878,7 +879,7 @@ public class CameraPreview: CAPPlugin, CAPBridgedPlugin, CLLocationManagerDelega
         }()
         print("[CameraPreview] Preview dimensions: \(previewWidth)x\(previewHeight)")
 
-        self.cameraController.captureImage(width: width, height: height, quality: quality, gpsLocation: self.currentLocation, embedTimestamp: embedTimestamp) { (image, originalPhotoData, _, error) in
+        self.cameraController.captureImage(width: width, height: height, quality: quality, gpsLocation: self.currentLocation, embedTimestamp: embedTimestamp, embedLocation: embedLocation) { (image, originalPhotoData, _, error) in
             print("[CameraPreview] captureImage callback received")
             DispatchQueue.main.async {
                 print("[CameraPreview] Processing capture on main thread")

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -255,6 +255,13 @@ export interface CameraPreviewPictureOptions {
    * @since 7.17.0
    */
   embedTimestamp?: boolean;
+  /**
+   * If true, the plugin will embed the current location in the top-right corner of the image.
+   * Requires `withExifLocation` to be enabled.
+   * @default false
+   * @since 7.18.0
+   */
+  embedLocation?: boolean;
 }
 
 /** Represents EXIF data extracted from an image. */


### PR DESCRIPTION
Introduces a new embedLocation boolean (default: false) that, when enabled and `withExifLocation` enabled, draws the location in the top-right corner of the captured image.

Handles both `embedLocation` and `embedTimestamp` being enable, or one or other.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added embedLocation option to overlay GPS coordinates on captured photos (optionally with timestamp). Displays as subtle pill(s) in the top-right on Android and iOS. Requires EXIF location to be enabled; off by default. Introduced in 7.18.0.

- **Documentation**
  - README updated to document the embedLocation option, behavior, and requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->