### PR TITLE
fix(android): CameraX stop deferral deadlocks

### DIFF
--- a/android/src/main/java/app/capgo/capacitor/camera/preview/CameraPreview.java
+++ b/android/src/main/java/app/capgo/capacitor/camera/preview/CameraPreview.java
@@ -239,7 +239,7 @@ public class CameraPreview
     // Prevent starting while an existing view is still active or stopping
     if (cameraXView != null) {
       try {
-        if (cameraXView.isRunning() && !cameraXView.isStopping())) {
+        if (cameraXView.isRunning() && !cameraXView.isStopping()) {
           call.reject("Camera is already running");
           return;
         }

--- a/android/src/main/java/app/capgo/capacitor/camera/preview/CameraPreview.java
+++ b/android/src/main/java/app/capgo/capacitor/camera/preview/CameraPreview.java
@@ -445,15 +445,11 @@ public class CameraPreview
         }
 
         if (cameraXView != null) {
-          boolean willDefer = false;
-          try {
-            willDefer = cameraXView.isCapturing();
-          } catch (Exception ignored) {}
           if (cameraXView.isRunning()) {
             cameraXView.stopSession();
           }
           // Only drop the reference if no deferred stop is pending
-          if (!willDefer) {
+          if (!cameraXView.isStopDeferred()) {
             cameraXView = null;
           }
         }

--- a/android/src/main/java/app/capgo/capacitor/camera/preview/CameraPreview.java
+++ b/android/src/main/java/app/capgo/capacitor/camera/preview/CameraPreview.java
@@ -239,11 +239,11 @@ public class CameraPreview
     // Prevent starting while an existing view is still active or stopping
     if (cameraXView != null) {
       try {
-        if (cameraXView.isRunning()) {
+        if (cameraXView.isRunning() && !cameraXView.isStopping())) {
           call.reject("Camera is already running");
           return;
         }
-        if (cameraXView.isBusy()) {
+        if (cameraXView.isStopping() || cameraXView.isBusy()) {
           if (enqueuePendingStart(call)) {
             Log.d(
               TAG,


### PR DESCRIPTION
- ensure every capture/focus path unwinds activeOperations and clears isCapturingPhoto even when a request fails or is cancelled

- add isStopDeferred()/isStopping() so the plugin can keep the existing CameraXView instance alive while a -deferred stop finishes

- stop dropping the view reference in CameraPreview.stop() when operations are still pending


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* New Features
  * Exposed stop-deferred status to observe deferred-stop behavior.
  * Optional Base64 capture output alongside file saving; preserved EXIF for in-memory outputs.

* Improvements
  * Stronger lifecycle synchronization to ensure operations end reliably.
  * Focus indicator lifecycle refined to avoid races and better UX.
  * Early "camera not ready" guards for capture flows.

* Bug Fixes
  * Ensured captures and focus operations always clean up, even on errors.
  * Clearer error reporting when capture components are unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->