### PR TITLE
fix(ios): initial zoom

### DIFF
--- a/example-app/src/app/components/camera-modal/camera-modal.component.html
+++ b/example-app/src/app/components/camera-modal/camera-modal.component.html
@@ -137,6 +137,28 @@
     </div>
   }
 
+  @if (cameraStarted() && zoomButtonValues().length) {
+    <div
+      class="zoom-button-stack"
+      [style.top]="
+        currentPreviewHeight() && currentPreviewY()
+        ? (currentPreviewHeight() + currentPreviewY() - 56) + 'px'
+        : '165px'
+      "
+    >
+      @for (value of zoomButtonValues(); track value) {
+        <!-- 56px is the height of the div -->
+        <ion-fab-button
+          size="small"
+          [class.active]="isZoomValueActive(value)"
+          (click)="selectZoomValue(value)"
+        >
+          <span>{{ formatZoomValue(value) }}x</span>
+        </ion-fab-button>
+      }
+    </div>
+  }
+
   <ion-fab
     class="camera-actions"
     slot="fixed"

--- a/example-app/src/app/components/camera-modal/camera-modal.component.scss
+++ b/example-app/src/app/components/camera-modal/camera-modal.component.scss
@@ -193,6 +193,39 @@ ion-content::part(background) {
   }
 }
 
+.zoom-button-stack {
+  position: absolute;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 80;
+  display: flex;
+  gap: 10px;
+  justify-content: center;
+  pointer-events: auto;
+
+  ion-fab-button {
+    --size: 48px;
+    --background: rgba(0, 0, 0, 0.7);
+    --background-activated: rgba(0, 0, 0, 0.85);
+    --background-hover: rgba(0, 0, 0, 0.85);
+    --color: white;
+    font-weight: 600;
+    font-size: 0.8rem;
+    letter-spacing: 0.5px;
+    box-shadow: 0 6px 18px rgba(0, 0, 0, 0.3);
+
+    span {
+      pointer-events: none;
+    }
+  }
+
+  ion-fab-button.active {
+    --background: rgba(var(--ion-color-primary-rgb), 0.95);
+    --color: #fff;
+    box-shadow: 0 6px 18px rgba(var(--ion-color-primary-rgb), 0.35);
+  }
+}
+
 
 
 // Toolbar and icons
@@ -343,6 +376,15 @@ ion-fab-button {
   }
 
 
+
+  .zoom-button-stack {
+    gap: 6px;
+
+    ion-fab-button {
+      --size: 44px;
+      font-size: 0.7rem;
+    }
+  }
 
     .test-results {
     left: 10px;

--- a/ios/Sources/CapgoCameraPreviewPlugin/CameraController.swift
+++ b/ios/Sources/CapgoCameraPreviewPlugin/CameraController.swift
@@ -71,7 +71,7 @@ class CameraController: NSObject {
     var audioDevice: AVCaptureDevice?
     var audioInput: AVCaptureDeviceInput?
 
-    var zoomFactor: CGFloat = 2.0
+    var zoomFactor: CGFloat = 1.0
     private var lastZoomUpdateTime: TimeInterval = 0
     private let zoomUpdateThrottle: TimeInterval = 1.0 / 60.0 // 60 FPS max
 
@@ -532,10 +532,10 @@ extension CameraController {
         let minZoom = device.minAvailableVideoZoomFactor
         let maxZoom = min(device.maxAvailableVideoZoomFactor, saneMaxZoomFactor)
 
-        // Compute UI-level default = 1 * multiplier when not provided
+        // Compute UI-level default (1×) when not provided
         let multiplier = self.getDisplayZoomMultiplier()
-        // if level is nil, it's the initial zoom
-        let uiLevel: Float = level ?? (2.0 * multiplier)
+        // If level is nil, fall back to a UI zoom of 1.0×
+        let uiLevel: Float = level ?? 1.0
         // Map UI/display zoom to native zoom using iOS 18+ multiplier
         let adjustedLevel = multiplier != 1.0 ? (uiLevel / multiplier) : uiLevel
 


### PR DESCRIPTION
# Description

- Native iOS preview now launches at the wide 1× baseline rather than trying to compensate baseline accoridng to iPhone versions (it's done afterwards)
- Add zoom buttons values to the example-app

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added zoom quick-select buttons in the camera modal, shown when the camera starts and supported zoom steps are available.
  - Tap to apply a zoom level; the active selection is highlighted with formatted labels (e.g., 2x).
  - Updated default camera zoom on iOS to start at 1x.

- Style
  - Introduced a vertically stacked, small FAB-style zoom control with responsive positioning for various preview sizes and smaller viewports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->