### PR TITLE
restore continuous auto-focus on device movement (iOS & Android)

### DIFF
--- a/android/src/main/java/app/capgo/capacitor/camera/preview/CameraXView.java
+++ b/android/src/main/java/app/capgo/capacitor/camera/preview/CameraXView.java
@@ -2251,9 +2251,8 @@ public class CameraXView implements LifecycleOwner, LifecycleObserver {
         MeteringPointFactory factory = previewView.getMeteringPointFactory();
         MeteringPoint point = factory.createPoint(x * viewWidth, y * viewHeight);
 
-        // Create focus and metering action (persistent, no auto-cancel) to match iOS behavior
+        // Create focus and metering action (resets after time to allow for auto focusing on movement later)
         FocusMeteringAction action = new FocusMeteringAction.Builder(point, FocusMeteringAction.FLAG_AF | FocusMeteringAction.FLAG_AE)
-            .disableAutoCancel()
             .build();
 
         if (IsOperationRunning("setFocus")) {

--- a/android/src/main/java/app/capgo/capacitor/camera/preview/CameraXView.java
+++ b/android/src/main/java/app/capgo/capacitor/camera/preview/CameraXView.java
@@ -2252,8 +2252,10 @@ public class CameraXView implements LifecycleOwner, LifecycleObserver {
         MeteringPoint point = factory.createPoint(x * viewWidth, y * viewHeight);
 
         // Create focus and metering action (resets after time to allow for auto focusing on movement later)
-        FocusMeteringAction action = new FocusMeteringAction.Builder(point, FocusMeteringAction.FLAG_AF | FocusMeteringAction.FLAG_AE)
-            .build();
+        FocusMeteringAction action = new FocusMeteringAction.Builder(
+            point,
+            FocusMeteringAction.FLAG_AF | FocusMeteringAction.FLAG_AE
+        ).build();
 
         if (IsOperationRunning("setFocus")) {
             Log.d(TAG, "setFocus: Ignored because stop is pending");

--- a/bun.lock
+++ b/bun.lock
@@ -13,7 +13,6 @@
         "@ionic/eslint-config": "^0.4.0",
         "@ionic/prettier-config": "^4.0.0",
         "@ionic/swiftlint-config": "^2.0.0",
-        "@rollup/rollup-darwin-x64": "^4.57.1",
         "@types/node": "^24.10.1",
         "eslint": "^8.57.1",
         "eslint-plugin-import": "^2.31.0",
@@ -108,7 +107,7 @@
 
     "@rollup/rollup-darwin-arm64": ["@rollup/rollup-darwin-arm64@4.53.3", "", { "os": "darwin", "cpu": "arm64" }, "sha512-Nr7SlQeqIBpOV6BHHGZgYBuSdanCXuw09hon14MGOLGmXAFYjx1wNvquVPmpZnl0tLjg25dEdr4IQ6GgyToCUA=="],
 
-    "@rollup/rollup-darwin-x64": ["@rollup/rollup-darwin-x64@4.57.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-Ji8g8ChVbKrhFtig5QBV7iMaJrGtpHelkB3lsaKzadFBe58gmjfGXAOfI5FV0lYMH8wiqsxKQ1C9B0YTRXVy4w=="],
+    "@rollup/rollup-darwin-x64": ["@rollup/rollup-darwin-x64@4.53.3", "", { "os": "darwin", "cpu": "x64" }, "sha512-DZ8N4CSNfl965CmPktJ8oBnfYr3F8dTTNBQkRlffnUarJ2ohudQD17sZBa097J8xhQ26AwhHJ5mvUyQW8ddTsQ=="],
 
     "@rollup/rollup-freebsd-arm64": ["@rollup/rollup-freebsd-arm64@4.53.3", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-yMTrCrK92aGyi7GuDNtGn2sNW+Gdb4vErx4t3Gv/Tr+1zRb8ax4z8GWVRfr3Jw8zJWvpGHNpss3vVlbF58DZ4w=="],
 
@@ -801,8 +800,6 @@
     "path-scurry/minipass": ["minipass@7.1.2", "", {}, "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw=="],
 
     "prompts/kleur": ["kleur@3.0.3", "", {}, "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w=="],
-
-    "rollup/@rollup/rollup-darwin-x64": ["@rollup/rollup-darwin-x64@4.53.3", "", { "os": "darwin", "cpu": "x64" }, "sha512-DZ8N4CSNfl965CmPktJ8oBnfYr3F8dTTNBQkRlffnUarJ2ohudQD17sZBa097J8xhQ26AwhHJ5mvUyQW8ddTsQ=="],
 
     "tsutils/tslib": ["tslib@1.14.1", "", {}, "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="],
 

--- a/ios/Sources/CapgoCameraPreviewPlugin/CameraController.swift
+++ b/ios/Sources/CapgoCameraPreviewPlugin/CameraController.swift
@@ -56,6 +56,43 @@ class CameraController: NSObject {
         }
     }
 
+    // Continuous focus with significant movement if focus was locked from setFocus earlier 
+    @objc private func subjectAreaDidChange(notification: NSNotification) {
+        guard let device = self.currentCameraPosition == .rear ? rearCamera : frontCamera else { return }
+        
+        do {
+            try device.lockForConfiguration()
+            defer { device.unlockForConfiguration() }
+            
+            // Reset Focus to the center and make it continuous
+            if device.isFocusModeSupported(.continuousAutoFocus) {
+                device.focusMode = .continuousAutoFocus
+                if device.isFocusPointOfInterestSupported {
+                    device.focusPointOfInterest = CGPoint(x: 0.5, y: 0.5)
+                }
+            }
+            
+            // 2. Reset Exposure to the center ONLY if it is not explicitly locked
+            if device.exposureMode != .locked {
+                if device.isExposureModeSupported(.continuousAutoExposure) {
+                    device.exposureMode = .continuousAutoExposure
+                    if device.isExposurePointOfInterestSupported {
+                        device.exposurePointOfInterest = CGPoint(x: 0.5, y: 0.5)
+                    }
+                    device.setExposureTargetBias(0.0) { _ in }
+                }
+            }
+            
+            // 3. Turn off monitoring until the user taps to focus again
+            device.isSubjectAreaChangeMonitoringEnabled = false
+            
+            print("[CameraPreview] Phone moved: Reset focus. Exposure reset skipped if locked.")
+            
+        } catch {
+            print("[CameraPreview] Failed to reset focus after subject area change: \(error)")
+        }
+    }
+    
     var captureSession: AVCaptureSession?
     var disableFocusIndicator: Bool = false
 
@@ -445,6 +482,9 @@ extension CameraController {
 
                 // Set initial zoom
                 self.setInitialZoom(level: initialZoomLevel)
+
+                // Set up listener for change in subject area of camera feed
+                NotificationCenter.default.addObserver(self, selector: #selector(self.subjectAreaDidChange), name: .AVCaptureDeviceSubjectAreaDidChange, object: nil)
 
                 // Start the session - all outputs are already configured
                 captureSession.startRunning()
@@ -1721,6 +1761,9 @@ extension CameraController {
             if autoFocus {
                 self.triggerAutoFocus()
             }
+
+            // Turn on subject area monitor for switch to continuous focus if needed
+            device.isSubjectAreaChangeMonitoringEnabled = true
         } catch {
             throw CameraControllerError.invalidOperation
         }
@@ -1999,6 +2042,8 @@ extension CameraController {
             captureSession.inputs.forEach { captureSession.removeInput($0) }
             captureSession.outputs.forEach { captureSession.removeOutput($0) }
         }
+        // Remove listener for subject area change
+        NotificationCenter.default.removeObserver(self, name: .AVCaptureDeviceSubjectAreaDidChange, object: nil)
 
         self.motionManager.stopAccelerometerUpdates()
         self.previewLayer?.removeFromSuperlayer()
@@ -2317,6 +2362,10 @@ extension CameraController: UIGestureRecognizerDelegate {
                     device.setExposureTargetBias(0.0) { _ in }
                 }
             }
+
+            // Turn on subject area monitor for switch to continuous focus if needed
+            device.isSubjectAreaChangeMonitoringEnabled = true
+
         } catch {
             debugPrint(error)
         }

--- a/ios/Sources/CapgoCameraPreviewPlugin/CameraController.swift
+++ b/ios/Sources/CapgoCameraPreviewPlugin/CameraController.swift
@@ -484,8 +484,13 @@ extension CameraController {
                 self.setInitialZoom(level: initialZoomLevel)
 
                 // Set up listener for change in subject area of camera feed
-                NotificationCenter.default.addObserver(self, selector: #selector(self.subjectAreaDidChange), name: .AVCaptureDeviceSubjectAreaDidChange, object: nil)
-
+                NotificationCenter.default.removeObserver(self, name: .AVCaptureDeviceSubjectAreaDidChange, object: nil)
+                NotificationCenter.default.addObserver(
+                    self,
+                    selector: `#selector`(self.subjectAreaDidChange),
+                    name: .AVCaptureDeviceSubjectAreaDidChange,
+                    object: nil
+                )
                 // Start the session - all outputs are already configured
                 captureSession.startRunning()
 

--- a/ios/Sources/CapgoCameraPreviewPlugin/CameraController.swift
+++ b/ios/Sources/CapgoCameraPreviewPlugin/CameraController.swift
@@ -484,6 +484,7 @@ extension CameraController {
                 self.setInitialZoom(level: initialZoomLevel)
 
                 // Set up listener for change in subject area of camera feed
+                NotificationCenter.default.removeObserver(self, name: .AVCaptureDeviceSubjectAreaDidChange, object: nil)
                 NotificationCenter.default.addObserver(self, selector: #selector(self.subjectAreaDidChange), name: .AVCaptureDeviceSubjectAreaDidChange, object: nil)
 
                 // Start the session - all outputs are already configured
@@ -1866,7 +1867,7 @@ extension CameraController {
                     device.exposurePointOfInterest = point
                 }
             }
-            
+
             // Turn on subject area monitor for switch to continuous focus if needed
             device.isSubjectAreaChangeMonitoringEnabled = true
 

--- a/ios/Sources/CapgoCameraPreviewPlugin/CameraController.swift
+++ b/ios/Sources/CapgoCameraPreviewPlugin/CameraController.swift
@@ -1761,9 +1761,6 @@ extension CameraController {
             if autoFocus {
                 self.triggerAutoFocus()
             }
-
-            // Turn on subject area monitor for switch to continuous focus if needed
-            device.isSubjectAreaChangeMonitoringEnabled = true
         } catch {
             throw CameraControllerError.invalidOperation
         }
@@ -1869,6 +1866,9 @@ extension CameraController {
                     device.exposurePointOfInterest = point
                 }
             }
+            
+            // Turn on subject area monitor for switch to continuous focus if needed
+            device.isSubjectAreaChangeMonitoringEnabled = true
 
             device.unlockForConfiguration()
         } catch {

--- a/ios/Sources/CapgoCameraPreviewPlugin/CameraController.swift
+++ b/ios/Sources/CapgoCameraPreviewPlugin/CameraController.swift
@@ -56,14 +56,14 @@ class CameraController: NSObject {
         }
     }
 
-    // Continuous focus with significant movement if focus was locked from setFocus earlier 
+    // Continuous focus with significant movement if focus was locked from setFocus earlier
     @objc private func subjectAreaDidChange(notification: NSNotification) {
         guard let device = self.currentCameraPosition == .rear ? rearCamera : frontCamera else { return }
-        
+
         do {
             try device.lockForConfiguration()
             defer { device.unlockForConfiguration() }
-            
+
             // Reset Focus to the center and make it continuous
             if device.isFocusModeSupported(.continuousAutoFocus) {
                 device.focusMode = .continuousAutoFocus
@@ -71,7 +71,7 @@ class CameraController: NSObject {
                     device.focusPointOfInterest = CGPoint(x: 0.5, y: 0.5)
                 }
             }
-            
+
             // 2. Reset Exposure to the center ONLY if it is not explicitly locked
             if device.exposureMode != .locked {
                 if device.isExposureModeSupported(.continuousAutoExposure) {
@@ -82,17 +82,17 @@ class CameraController: NSObject {
                     device.setExposureTargetBias(0.0) { _ in }
                 }
             }
-            
+
             // 3. Turn off monitoring until the user taps to focus again
             device.isSubjectAreaChangeMonitoringEnabled = false
-            
+
             print("[CameraPreview] Phone moved: Reset focus. Exposure reset skipped if locked.")
-            
+
         } catch {
             print("[CameraPreview] Failed to reset focus after subject area change: \(error)")
         }
     }
-    
+
     var captureSession: AVCaptureSession?
     var disableFocusIndicator: Bool = false
 
@@ -2285,7 +2285,7 @@ extension CameraController {
             if connection.isEnabled == false { connection.isEnabled = true }
             // Goes off accelerometer now
             connection.videoOrientation = self.getPhysicalOrientation()
-            
+
             // Front camera: mirror the recorded video so it looks natural (selfie style).
             if self.currentCameraPosition == .front, connection.isVideoMirroringSupported {
                 connection.isVideoMirrored = true


### PR DESCRIPTION
## What:

This PR fixes an issue where the camera focus becomes "stuck" after a user manually triggers setFocus (or taps to focus). Previously, the lens would remain locked on the manual focal point even if the user panned the device to a completely different scene.

This update ensures that both platforms gracefully return to Continuous Auto-Focus / Auto-Exposure when the camera detects significant movement or after the native timeout.

## Why: 

In it's current state the camera did not work in a similar fashion to the mobile device's native camera. If a user ever clicked to focus on something and then moved the camera to look at something else it would not auto adjust like the native camera does. This left the user to have continually press focus to get rid of blur.
## How:
iOS Changes:

Implemented the AVCaptureDeviceSubjectAreaDidChange hardware notification.

Battery Optimized: The movement monitor (isSubjectAreaChangeMonitoringEnabled) is left off by default. It is now explicitly armed only inside setFocus and handleTap.

Once the hardware detects a significant scene shift (movement/lighting change), the observer catches it, safely resets the focus/exposure modes to .continuous, and disarms the monitor until the next manual tap.

Added protections so manual exposure locks are respected during a focus reset.

Android Changes:

Removed the .disableAutoCancel() flag from the FocusMeteringAction.Builder inside the setFocus method.

Why: CameraX natively handles canceling a manual focus point after a few seconds to return to continuous AF. By forcing .disableAutoCancel(), the plugin was overriding this native behavior and permanently locking the lens. Removing this single line restores expected native Android camera behavior.

## Testing Performed:

Verified iOS hardware monitor correctly catches movement and triggers the reset block.

Verified Android compiles cleanly and correctly executes the native CameraX focus timeout without throwing.

## Not Tested:
Non Samsung androids

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * iOS: Camera now monitors subject-area changes and automatically resets focus and exposure to continuous modes and recenters points after user interactions, improving stability after scene shifts.
  * Android: Focus metering now uses the platform's default auto-cancel behavior instead of persisting indefinitely, improving focus responsiveness and reducing stuck metering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->