### PR TITLE
fix(android): Prevent lifecycle state transitions from DESTROYED in CameraXView

### DIFF
--- a/android/src/main/java/app/capgo/capacitor/camera/preview/CameraXView.java
+++ b/android/src/main/java/app/capgo/capacitor/camera/preview/CameraXView.java
@@ -268,7 +268,11 @@ public class CameraXView implements LifecycleOwner, LifecycleObserver {
         this.lifecycleRegistry = new LifecycleRegistry(this);
         this.mainExecutor = ContextCompat.getMainExecutor(context);
 
-        mainExecutor.execute(() -> lifecycleRegistry.setCurrentState(Lifecycle.State.CREATED));
+        mainExecutor.execute(() -> {
+            if (lifecycleRegistry.getCurrentState() != Lifecycle.State.DESTROYED) {
+                lifecycleRegistry.setCurrentState(Lifecycle.State.CREATED);
+            }
+        });
     }
 
     @NonNull
@@ -419,7 +423,22 @@ public class CameraXView implements LifecycleOwner, LifecycleObserver {
             stopPending = false;
         }
         mainExecutor.execute(() -> {
+            // Stop may run first (e.g. activity pause) and move the registry to DESTROYED while this
+            // runnable is still queued — never transition backward from DESTROYED.
+            if (lifecycleRegistry.getCurrentState() == Lifecycle.State.DESTROYED || stopRequested) {
+                return;
+            }
+            Lifecycle.State state = lifecycleRegistry.getCurrentState();
+            if (state == Lifecycle.State.INITIALIZED) {
+                lifecycleRegistry.setCurrentState(Lifecycle.State.CREATED);
+                if (lifecycleRegistry.getCurrentState() == Lifecycle.State.DESTROYED || stopRequested) {
+                    return;
+                }
+            }
             lifecycleRegistry.setCurrentState(Lifecycle.State.STARTED);
+            if (lifecycleRegistry.getCurrentState() == Lifecycle.State.DESTROYED || stopRequested) {
+                return;
+            }
             setupCamera();
         });
     }
@@ -483,7 +502,6 @@ public class CameraXView implements LifecycleOwner, LifecycleObserver {
                 if (cameraProvider != null) {
                     cameraProvider.unbindAll();
                 }
-                lifecycleRegistry.setCurrentState(Lifecycle.State.DESTROYED);
                 if (cameraExecutor != null) {
                     cameraExecutor.shutdown();
                 }
@@ -527,7 +545,13 @@ public class CameraXView implements LifecycleOwner, LifecycleObserver {
         cameraProviderFuture.addListener(
             () -> {
                 try {
+                    if (lifecycleRegistry.getCurrentState() == Lifecycle.State.DESTROYED || stopRequested) {
+                        return;
+                    }
                     cameraProvider = cameraProviderFuture.get();
+                    if (lifecycleRegistry.getCurrentState() == Lifecycle.State.DESTROYED || stopRequested) {
+                        return;
+                    }
                     setupPreviewView();
                     bindCameraUseCases();
                 } catch (Exception e) {

--- a/android/src/main/java/app/capgo/capacitor/camera/preview/CameraXView.java
+++ b/android/src/main/java/app/capgo/capacitor/camera/preview/CameraXView.java
@@ -394,34 +394,6 @@ public class CameraXView implements LifecycleOwner, LifecycleObserver {
     }
 
     public void startSession(CameraSessionConfiguration config) {
-        this.sessionConfig = config;
-        cameraExecutor = Executors.newSingleThreadExecutor();
-
-        // Reset cached orientation so we don't reuse stale values across sessions
-        synchronized (accelerometerLock) {
-            lastAccelerometerValues[0] = 0f;
-            lastAccelerometerValues[1] = 0f;
-            lastAccelerometerValues[2] = 0f;
-        }
-        lastCaptureRotation = -1;
-
-        // Start accelerometer for orientation detection regardless of lock
-        if (sensorManager == null) {
-            sensorManager = (SensorManager) context.getSystemService(Context.SENSOR_SERVICE);
-            accelerometer = sensorManager.getDefaultSensor(Sensor.TYPE_ACCELEROMETER);
-            rotationVectorSensor = sensorManager.getDefaultSensor(Sensor.TYPE_ROTATION_VECTOR);
-        }
-        if (accelerometer != null) {
-            sensorManager.registerListener(accelerometerListener, accelerometer, SensorManager.SENSOR_DELAY_UI);
-        }
-        if (rotationVectorSensor != null) {
-            sensorManager.registerListener(rotationVectorListener, rotationVectorSensor, SensorManager.SENSOR_DELAY_NORMAL);
-        }
-        lastCompassHeading = -1f;
-        synchronized (operationLock) {
-            activeOperations = 0;
-            stopPending = false;
-        }
         mainExecutor.execute(() -> {
             // Stop may run first (e.g. activity pause) and move the registry to DESTROYED while this
             // runnable is still queued — never transition backward from DESTROYED.
@@ -477,6 +449,35 @@ public class CameraXView implements LifecycleOwner, LifecycleObserver {
                     listener.onCameraStartError("Camera start aborted: stop requested");
                 }
                 return;
+            }
+
+            this.sessionConfig = config;
+            cameraExecutor = Executors.newSingleThreadExecutor();
+
+            // Reset cached orientation so we don't reuse stale values across sessions
+            synchronized (accelerometerLock) {
+                lastAccelerometerValues[0] = 0f;
+                lastAccelerometerValues[1] = 0f;
+                lastAccelerometerValues[2] = 0f;
+            }
+            lastCaptureRotation = -1;
+
+            // Start accelerometer for orientation detection regardless of lock
+            if (sensorManager == null) {
+                sensorManager = (SensorManager) context.getSystemService(Context.SENSOR_SERVICE);
+                accelerometer = sensorManager.getDefaultSensor(Sensor.TYPE_ACCELEROMETER);
+                rotationVectorSensor = sensorManager.getDefaultSensor(Sensor.TYPE_ROTATION_VECTOR);
+            }
+            if (accelerometer != null) {
+                sensorManager.registerListener(accelerometerListener, accelerometer, SensorManager.SENSOR_DELAY_UI);
+            }
+            if (rotationVectorSensor != null) {
+                sensorManager.registerListener(rotationVectorListener, rotationVectorSensor, SensorManager.SENSOR_DELAY_NORMAL);
+            }
+            lastCompassHeading = -1f;
+            synchronized (operationLock) {
+                activeOperations = 0;
+                stopPending = false;
             }
             setupCamera();
         });

--- a/android/src/main/java/app/capgo/capacitor/camera/preview/CameraXView.java
+++ b/android/src/main/java/app/capgo/capacitor/camera/preview/CameraXView.java
@@ -425,21 +425,57 @@ public class CameraXView implements LifecycleOwner, LifecycleObserver {
         mainExecutor.execute(() -> {
             // Stop may run first (e.g. activity pause) and move the registry to DESTROYED while this
             // runnable is still queued — never transition backward from DESTROYED.
-            if (lifecycleRegistry.getCurrentState() == Lifecycle.State.DESTROYED || stopRequested) {
+            if (lifecycleRegistry.getCurrentState() == Lifecycle.State.DESTROYED) {
+                if (listener != null) {
+                    listener.onCameraStartError("Camera start aborted: lifecycle destroyed");
+                }
+                return;
+            }
+            if (stopRequested) {
+                if (listener != null) {
+                    listener.onCameraStartError("Camera start aborted: stop requested");
+                }
                 return;
             }
             Lifecycle.State state = lifecycleRegistry.getCurrentState();
             if (state == Lifecycle.State.INITIALIZED) {
                 lifecycleRegistry.setCurrentState(Lifecycle.State.CREATED);
-                if (lifecycleRegistry.getCurrentState() == Lifecycle.State.DESTROYED || stopRequested) {
+                if (lifecycleRegistry.getCurrentState() == Lifecycle.State.DESTROYED) {
+                    if (listener != null) {
+                        listener.onCameraStartError("Camera start aborted: lifecycle destroyed");
+                    }
+                    return;
+                }
+                if (stopRequested) {
+                    if (listener != null) {
+                        listener.onCameraStartError("Camera start aborted: stop requested");
+                    }
                     return;
                 }
             }
-            if (lifecycleRegistry.getCurrentState() == Lifecycle.State.DESTROYED || stopRequested) {
+            if (lifecycleRegistry.getCurrentState() == Lifecycle.State.DESTROYED) {
+                if (listener != null) {
+                    listener.onCameraStartError("Camera start aborted: lifecycle destroyed");
+                }
+                return;
+            }
+            if (stopRequested) {
+                if (listener != null) {
+                    listener.onCameraStartError("Camera start aborted: stop requested");
+                }
                 return;
             }
             lifecycleRegistry.setCurrentState(Lifecycle.State.STARTED);
-            if (lifecycleRegistry.getCurrentState() == Lifecycle.State.DESTROYED || stopRequested) {
+            if (lifecycleRegistry.getCurrentState() == Lifecycle.State.DESTROYED) {
+                if (listener != null) {
+                    listener.onCameraStartError("Camera start aborted: lifecycle destroyed");
+                }
+                return;
+            }
+            if (stopRequested) {
+                if (listener != null) {
+                    listener.onCameraStartError("Camera start aborted: stop requested");
+                }
                 return;
             }
             setupCamera();
@@ -548,11 +584,29 @@ public class CameraXView implements LifecycleOwner, LifecycleObserver {
         cameraProviderFuture.addListener(
             () -> {
                 try {
-                    if (lifecycleRegistry.getCurrentState() == Lifecycle.State.DESTROYED || stopRequested) {
+                    if (lifecycleRegistry.getCurrentState() == Lifecycle.State.DESTROYED) {
+                        if (listener != null) {
+                            listener.onCameraStartError("Camera binding cancelled: lifecycle destroyed (before provider)");
+                        }
+                        return;
+                    }
+                    if (stopRequested) {
+                        if (listener != null) {
+                            listener.onCameraStartError("Camera binding cancelled: stop requested (before provider)");
+                        }
                         return;
                     }
                     cameraProvider = cameraProviderFuture.get();
-                    if (lifecycleRegistry.getCurrentState() == Lifecycle.State.DESTROYED || stopRequested) {
+                    if (lifecycleRegistry.getCurrentState() == Lifecycle.State.DESTROYED) {
+                        if (listener != null) {
+                            listener.onCameraStartError("Camera binding cancelled: lifecycle destroyed (after provider)");
+                        }
+                        return;
+                    }
+                    if (stopRequested) {
+                        if (listener != null) {
+                            listener.onCameraStartError("Camera binding cancelled: stop requested (after provider)");
+                        }
                         return;
                     }
                     setupPreviewView();

--- a/android/src/main/java/app/capgo/capacitor/camera/preview/CameraXView.java
+++ b/android/src/main/java/app/capgo/capacitor/camera/preview/CameraXView.java
@@ -435,6 +435,9 @@ public class CameraXView implements LifecycleOwner, LifecycleObserver {
                     return;
                 }
             }
+            if (lifecycleRegistry.getCurrentState() == Lifecycle.State.DESTROYED || stopRequested) {
+                return;
+            }
             lifecycleRegistry.setCurrentState(Lifecycle.State.STARTED);
             if (lifecycleRegistry.getCurrentState() == Lifecycle.State.DESTROYED || stopRequested) {
                 return;


### PR DESCRIPTION
Hello ! There was an app crash on android for some reason on my table, it was hard to reproduce but this commit will fix the issue and prevent a crash.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved camera preview lifecycle handling to prevent invalid state transitions and redundant operations. Startup now aborts cleanly if a stop/destroy is requested, reports start errors on abort, avoids binding/preview setup during teardown, and removes redundant teardown calls—enhancing stability and reducing race-condition crashes during camera start/stop.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->