### PR TITLE
fix(android): restore system UI for foreground starts

### DIFF
--- a/android/src/main/java/app/capgo/capacitor/camera/preview/CameraPreview.java
+++ b/android/src/main/java/app/capgo/capacitor/camera/preview/CameraPreview.java
@@ -1685,6 +1685,7 @@ public class CameraPreview extends Plugin implements CameraXView.CameraXViewList
             return;
         }
         if (!toBack) {
+            restoreSystemUiForToBackMode(activity);
             return;
         }
 
@@ -2211,20 +2212,20 @@ public class CameraPreview extends Plugin implements CameraXView.CameraXViewList
         DisplayMetrics metrics = getBridge().getActivity().getResources().getDisplayMetrics();
         float pixelRatio = metrics.density;
 
-		// Check if edge-to-edge mode is active
-		WebView webView = getBridge().getWebView();
-		int webViewTopInset = 0;
-		if (webView != null) {
-			int[] location = new int[2];
-			webView.getLocationOnScreen(location);
-			webViewTopInset = location[1];
-		}
-		final boolean isWebViewOffset = webViewTopInset > 0;
-		final int safeAreaTopInsetPx = lastIncludeSafeAreaInsets ? getSafeAreaTopInsetPx() : 0;
-		final float pixelRatioFinal = pixelRatio;
+        // Check if edge-to-edge mode is active
+        WebView webView = getBridge().getWebView();
+        int webViewTopInset = 0;
+        if (webView != null) {
+            int[] location = new int[2];
+            webView.getLocationOnScreen(location);
+            webViewTopInset = location[1];
+        }
+        final boolean isWebViewOffset = webViewTopInset > 0;
+        final int safeAreaTopInsetPx = lastIncludeSafeAreaInsets ? getSafeAreaTopInsetPx() : 0;
+        final float pixelRatioFinal = pixelRatio;
 
-		int x = (xParam != null && xParam > 0) ? (int) (xParam * pixelRatio) : 0;
-		int y = (yParam != null && yParam > 0) ? (int) (yParam * pixelRatio) : 0;
+        int x = (xParam != null && xParam > 0) ? (int) (xParam * pixelRatio) : 0;
+        int y = (yParam != null && yParam > 0) ? (int) (yParam * pixelRatio) : 0;
 
         // Add inset to Y for coordinate conversion if needed.
         // - If the WebView is already offset from the screen top, use that.
@@ -2237,14 +2238,14 @@ public class CameraPreview extends Plugin implements CameraXView.CameraXViewList
         int width = (widthParam != null && widthParam > 0) ? (int) (widthParam * pixelRatio) : 0;
         int height = (heightParam != null && heightParam > 0) ? (int) (heightParam * pixelRatio) : 0;
 
-		cameraXView.setPreviewSize(x, y, width, height, () -> {
-			// Return the actual preview bounds after layout operations are complete
-			int[] bounds = cameraXView.getCurrentPreviewBounds();
-			if (!isWebViewOffset && lastIncludeSafeAreaInsets && safeAreaTopInsetPx > 0) {
-				int safeAreaTopInsetLogical = (int) Math.ceil(safeAreaTopInsetPx / pixelRatioFinal);
-				bounds[1] = Math.max(0, bounds[1] - safeAreaTopInsetLogical);
-			}
-			JSObject ret = new JSObject();
+        cameraXView.setPreviewSize(x, y, width, height, () -> {
+            // Return the actual preview bounds after layout operations are complete
+            int[] bounds = cameraXView.getCurrentPreviewBounds();
+            if (!isWebViewOffset && lastIncludeSafeAreaInsets && safeAreaTopInsetPx > 0) {
+                int safeAreaTopInsetLogical = (int) Math.ceil(safeAreaTopInsetPx / pixelRatioFinal);
+                bounds[1] = Math.max(0, bounds[1] - safeAreaTopInsetLogical);
+            }
+            JSObject ret = new JSObject();
             ret.put("x", bounds[0]);
             ret.put("y", bounds[1]);
             ret.put("width", bounds[2]);


### PR DESCRIPTION
## What
- Restore cached Android system bar state when starting a non-`toBack` camera session.
- Keep formatted Android source after running the repo formatter.

## Why
- Addresses the latest review comment on #336: `start({ force: true, toBack: false })` could stop a previous `toBack` session without restoring status/navigation bar colors and navigation contrast.

## How
- Reuse the existing system UI restore path before returning from the non-`toBack` branch of `lockSystemUiForToBackMode`.

## Testing
- `bun run fmt`
- `bun run verify`
- `bun run lint`

## Not Tested
- Manual Android device camera restart flow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed system UI state not being properly restored when switching camera modes
  * Improved camera preview positioning and sizing calculations for better accuracy
  * Enhanced safe area handling for edge-to-edge camera preview displays

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Cap-go/capacitor-camera-preview/pull/356?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->