### PR TITLE
[codex] Fix Android toBack preview flicker

### DIFF
--- a/android/src/main/java/app/capgo/capacitor/camera/preview/CameraPreview.java
+++ b/android/src/main/java/app/capgo/capacitor/camera/preview/CameraPreview.java
@@ -1628,7 +1628,7 @@ public class CameraPreview extends Plugin implements CameraXView.CameraXViewList
             return;
         }
         // Ensure reference is cleared once the originating CameraXView has fully stopped
-        if (cameraXView == source) {
+        if (source != null && cameraXView == source) {
             cameraXView = null;
         }
         if (!toBackVisualStateActive) {
@@ -2161,10 +2161,16 @@ public class CameraPreview extends Plugin implements CameraXView.CameraXViewList
             Log.d(TAG, "onCameraStartError: ignoring callback from stale instance");
             return;
         }
-        if (cameraXView == source) {
-            cameraXView = null;
-        }
         toBackVisualStateActive = false;
+        if (cameraXView == source) {
+            try {
+                // Keep the reference until onCameraStopped clears it after native cleanup.
+                source.stopSession();
+            } catch (Exception e) {
+                Log.w(TAG, "onCameraStartError: failed to stop failed camera session", e);
+                cameraXView = null;
+            }
+        }
 
         PluginCall call = bridge.getSavedCall(cameraStartCallbackId);
         if (call != null) {

--- a/android/src/main/java/app/capgo/capacitor/camera/preview/CameraPreview.java
+++ b/android/src/main/java/app/capgo/capacitor/camera/preview/CameraPreview.java
@@ -1879,16 +1879,23 @@ public class CameraPreview extends Plugin implements CameraXView.CameraXViewList
 
         Activity activity = getActivity();
         WebView webView = getBridge().getWebView();
-        final Float alphaToRestore = originalWebViewAlpha;
-        final Drawable webViewBackground = originalWebViewBackground;
-        final boolean webViewBackgroundCaptured = originalWebViewBackgroundCaptured;
-        final Drawable parentBackground = originalWebViewParentBackground;
-        final boolean parentBackgroundCaptured = originalWebViewParentBackgroundCaptured;
-        originalWebViewAlpha = null;
-        originalWebViewBackground = null;
-        originalWebViewBackgroundCaptured = false;
-        originalWebViewParentBackground = null;
-        originalWebViewParentBackgroundCaptured = false;
+        final Float alphaToRestore;
+        final Drawable webViewBackground;
+        final boolean webViewBackgroundCaptured;
+        final Drawable parentBackground;
+        final boolean parentBackgroundCaptured;
+        synchronized (this) {
+            alphaToRestore = originalWebViewAlpha;
+            webViewBackground = originalWebViewBackground;
+            webViewBackgroundCaptured = originalWebViewBackgroundCaptured;
+            parentBackground = originalWebViewParentBackground;
+            parentBackgroundCaptured = originalWebViewParentBackgroundCaptured;
+            originalWebViewAlpha = null;
+            originalWebViewBackground = null;
+            originalWebViewBackgroundCaptured = false;
+            originalWebViewParentBackground = null;
+            originalWebViewParentBackgroundCaptured = false;
+        }
 
         if (alphaToRestore == null && !webViewBackgroundCaptured && !parentBackgroundCaptured) {
             return;

--- a/android/src/main/java/app/capgo/capacitor/camera/preview/CameraPreview.java
+++ b/android/src/main/java/app/capgo/capacitor/camera/preview/CameraPreview.java
@@ -1338,6 +1338,7 @@ public class CameraPreview extends Plugin implements CameraXView.CameraXViewList
                 config.setTargetZoom(finalTargetZoom);
                 config.setCentered(isCentered);
                 config.setEnablePhysicalDeviceSelection(enablePhysicalDeviceSelection);
+                config.setBarcodeScannerEnabled(barcodeScannerOptions != null);
                 setPendingStartBarcodeScanner(barcodeScannerOptions);
 
                 bridge.saveCall(call);

--- a/android/src/main/java/app/capgo/capacitor/camera/preview/CameraPreview.java
+++ b/android/src/main/java/app/capgo/capacitor/camera/preview/CameraPreview.java
@@ -83,20 +83,19 @@ public class CameraPreview extends Plugin implements CameraXView.CameraXViewList
     protected void handleOnResume() {
         super.handleOnResume();
         if (lastSessionConfig != null) {
-            // Set to black to avoid flicker, transparent set later
-            if (lastSessionConfig.isToBack()) {
-                try {
-                    getBridge()
-                        .getActivity()
-                        .getWindow()
-                        .setBackgroundDrawable(new android.graphics.drawable.ColorDrawable(android.graphics.Color.BLACK));
-                    getBridge().getWebView().setBackgroundColor(android.graphics.Color.BLACK);
-                } catch (Exception ignored) {}
-            }
             // Recreate camera with last known configuration
-            if (cameraXView == null) {
+            if (cameraXView == null || !cameraXView.isRunning() || cameraXView.isStopping()) {
                 cameraXView = new CameraXView(getContext(), getBridge().getWebView());
                 cameraXView.setListener(this);
+            }
+            if (lastSessionConfig.isToBack()) {
+                if (usesFullStackTransparentBackgroundWorkaround()) {
+                    activateTransparentBackgroundsForToBack(cameraXView);
+                } else {
+                    prepareTransparentBackgroundsForToBack(cameraXView);
+                }
+            } else {
+                toBackVisualStateActive = false;
             }
             cameraXView.startSession(lastSessionConfig);
         }
@@ -110,12 +109,16 @@ public class CameraPreview extends Plugin implements CameraXView.CameraXViewList
             cameraXView = null;
         }
         lastSessionConfig = null;
+        toBackVisualStateActive = false;
+        restoreOriginalWindowBackground(getBridge().getActivity());
+        restoreWebViewVisualState();
         restoreSystemUiForToBackMode(getBridge().getActivity());
     }
 
     private CameraSessionConfiguration lastSessionConfig;
 
     private static final String TAG = "CameraPreview CameraXView";
+    private static final int DEFAULT_WEB_VIEW_BACKGROUND = Color.WHITE;
 
     static final String CAMERA_WITH_AUDIO_PERMISSION_ALIAS = "cameraWithAudio";
     static final String CAMERA_ONLY_PERMISSION_ALIAS = "cameraOnly";
@@ -138,11 +141,16 @@ public class CameraPreview extends Plugin implements CameraXView.CameraXViewList
     private boolean lastDisableAudio = true;
     private boolean lastIncludeSafeAreaInsets = false;
     private Drawable originalWindowBackground;
+    private boolean originalWindowBackgroundCaptured = false;
+    private Drawable originalWebViewBackground;
+    private boolean originalWebViewBackgroundCaptured = false;
     private Float originalWebViewAlpha;
     private Drawable originalWebViewParentBackground;
+    private boolean originalWebViewParentBackgroundCaptured = false;
     private Integer originalStatusBarColor;
     private Integer originalNavigationBarColor;
     private Boolean originalNavigationBarContrastEnforced;
+    private volatile boolean toBackVisualStateActive = false;
     private boolean isCameraPermissionDialogShowing = false;
     private boolean pendingStartBarcodeScanner = false;
     private List<String> pendingStartBarcodeFormats = new ArrayList<>();
@@ -524,13 +532,8 @@ public class CameraPreview extends Plugin implements CameraXView.CameraXViewList
                 }
                 // Manual stops should not trigger automatic resume with stale config
                 lastSessionConfig = null;
-                // Restore original window background if modified earlier
-                if (originalWindowBackground != null) {
-                    try {
-                        getBridge().getActivity().getWindow().setBackgroundDrawable(originalWindowBackground);
-                    } catch (Exception ignored) {}
-                    originalWindowBackground = null;
-                }
+                toBackVisualStateActive = false;
+                restoreOriginalWindowBackground(getBridge().getActivity());
                 restoreWebViewVisualState();
                 restoreSystemUiForToBackMode(getBridge().getActivity());
                 call.resolve();
@@ -1051,16 +1054,14 @@ public class CameraPreview extends Plugin implements CameraXView.CameraXViewList
             .getActivity()
             .runOnUiThread(() -> {
                 lockSystemUiForToBackMode(getBridge().getActivity(), toBack);
-                // Ensure transparent background when preview is behind the WebView (Android 10 fix)
                 if (toBack) {
-                    try {
-                        if (originalWindowBackground == null) {
-                            originalWindowBackground = getBridge().getActivity().getWindow().getDecorView().getBackground();
-                        }
-                        // Set to solid black first to prevent flickering during transition
-                        // This provides a stable base before camera preview is ready
-                        getBridge().getActivity().getWindow().setBackgroundDrawable(new ColorDrawable(Color.BLACK));
-                    } catch (Exception ignored) {}
+                    if (usesFullStackTransparentBackgroundWorkaround()) {
+                        activateTransparentBackgroundsForToBack(cameraXView);
+                    } else {
+                        prepareTransparentBackgroundsForToBack(cameraXView);
+                    }
+                } else {
+                    toBackVisualStateActive = false;
                 }
                 DisplayMetrics metrics = getBridge().getActivity().getResources().getDisplayMetrics();
                 if (lockOrientation) {
@@ -1629,7 +1630,9 @@ public class CameraPreview extends Plugin implements CameraXView.CameraXViewList
         if (cameraXView == source) {
             cameraXView = null;
         }
-        restoreWebViewVisualState();
+        if (!toBackVisualStateActive) {
+            restoreWebViewVisualState();
+        }
 
         PluginCall queuedCall = null;
         synchronized (pendingStartLock) {
@@ -1674,6 +1677,72 @@ public class CameraPreview extends Plugin implements CameraXView.CameraXViewList
         String manufacturer = Build.MANUFACTURER != null ? Build.MANUFACTURER.toLowerCase(Locale.US) : "";
         String brand = Build.BRAND != null ? Build.BRAND.toLowerCase(Locale.US) : "";
         return manufacturer.contains("xiaomi") || brand.contains("xiaomi") || brand.contains("redmi") || brand.contains("poco");
+    }
+
+    private boolean usesFullStackTransparentBackgroundWorkaround() {
+        String manufacturer = Build.MANUFACTURER != null ? Build.MANUFACTURER.toLowerCase(Locale.US) : "";
+        String brand = Build.BRAND != null ? Build.BRAND.toLowerCase(Locale.US) : "";
+        return (
+            isMiuiDevice() ||
+            manufacturer.contains("huawei") ||
+            manufacturer.contains("honor") ||
+            brand.contains("huawei") ||
+            brand.contains("honor")
+        );
+    }
+
+    private void captureOriginalWindowBackground(Activity activity) {
+        if (activity == null) {
+            return;
+        }
+        synchronized (this) {
+            if (!originalWindowBackgroundCaptured) {
+                originalWindowBackground = activity.getWindow().getDecorView().getBackground();
+                originalWindowBackgroundCaptured = true;
+            }
+        }
+    }
+
+    private void captureOriginalWebViewVisualState(WebView webView, ViewGroup webViewParent) {
+        if (webView == null) {
+            return;
+        }
+        synchronized (this) {
+            if (!originalWebViewBackgroundCaptured) {
+                originalWebViewBackground = webView.getBackground();
+                originalWebViewBackgroundCaptured = true;
+            }
+            if (originalWebViewAlpha == null) {
+                originalWebViewAlpha = webView.getAlpha();
+            }
+            if (webViewParent != null && !originalWebViewParentBackgroundCaptured) {
+                originalWebViewParentBackground = webViewParent.getBackground();
+                originalWebViewParentBackgroundCaptured = true;
+            }
+        }
+    }
+
+    private void restoreOriginalWindowBackground(Activity activity) {
+        final Drawable backgroundToRestore;
+        final boolean captured;
+        synchronized (this) {
+            backgroundToRestore = originalWindowBackground;
+            captured = originalWindowBackgroundCaptured;
+            originalWindowBackground = null;
+            originalWindowBackgroundCaptured = false;
+        }
+
+        if (!captured || activity == null) {
+            return;
+        }
+
+        activity.runOnUiThread(() -> {
+            try {
+                activity.getWindow().setBackgroundDrawable(backgroundToRestore);
+            } catch (Exception e) {
+                Log.w(TAG, "Failed to restore window background", e);
+            }
+        });
     }
 
     private int toOpaqueColor(int color) {
@@ -1741,35 +1810,46 @@ public class CameraPreview extends Plugin implements CameraXView.CameraXViewList
         });
     }
 
-    private void applyTransparentBackgroundsForToBack() {
-        if (!isToBackMode()) {
-            return;
-        }
+    private void prepareTransparentBackgroundsForToBack(CameraXView visualStateOwner) {
         Activity activity = getActivity();
         WebView webView = getBridge().getWebView();
         if (activity == null || webView == null) {
             return;
         }
 
-        if (originalWebViewAlpha == null) {
-            originalWebViewAlpha = webView.getAlpha();
+        toBackVisualStateActive = true;
+        final ViewGroup webViewParent = (ViewGroup) webView.getParent();
+        captureOriginalWindowBackground(activity);
+        captureOriginalWebViewVisualState(webView, webViewParent);
+    }
+
+    private void activateTransparentBackgroundsForToBack(CameraXView visualStateOwner) {
+        prepareTransparentBackgroundsForToBack(visualStateOwner);
+        Activity activity = getActivity();
+        WebView webView = getBridge().getWebView();
+        if (activity == null || webView == null) {
+            return;
         }
 
         final ViewGroup webViewParent = (ViewGroup) webView.getParent();
-        if (webViewParent != null && originalWebViewParentBackground == null) {
-            originalWebViewParentBackground = webViewParent.getBackground();
-        }
 
         Runnable apply = () -> {
             try {
-                activity.getWindow().setBackgroundDrawable(new ColorDrawable(Color.TRANSPARENT));
-                if (webViewParent != null) {
+                if (!toBackVisualStateActive || visualStateOwner == null || cameraXView != visualStateOwner) {
+                    return;
+                }
+                boolean fullStackWorkaround = usesFullStackTransparentBackgroundWorkaround();
+                if (fullStackWorkaround) {
+                    activity.getWindow().setBackgroundDrawable(new ColorDrawable(Color.TRANSPARENT));
+                }
+                if (webViewParent != null && fullStackWorkaround) {
                     webViewParent.setBackgroundColor(Color.TRANSPARENT);
                 }
-                // Keep a tiny alpha on MIUI/Xiaomi devices to avoid compositor bugs that treat
-                // fully transparent layers as black.
-                webView.setBackgroundColor(Color.argb(1, 255, 255, 255));
+                webView.setBackgroundColor(isMiuiDevice() ? Color.argb(1, 255, 255, 255) : Color.TRANSPARENT);
                 webView.setAlpha(isMiuiDevice() ? 0.99f : (originalWebViewAlpha != null ? originalWebViewAlpha : 1f));
+                if (webViewParent != null) {
+                    webViewParent.requestTransparentRegion(webView);
+                }
             } catch (Exception e) {
                 Log.w(TAG, "Failed to set backgrounds to transparent", e);
             }
@@ -1784,13 +1864,34 @@ public class CameraPreview extends Plugin implements CameraXView.CameraXViewList
         });
     }
 
+    private void applyTransparentBackgroundsForToBack() {
+        if (!isToBackMode()) {
+            return;
+        }
+        activateTransparentBackgroundsForToBack(cameraXView);
+    }
+
     private void restoreWebViewVisualState() {
+        if (toBackVisualStateActive) {
+            return;
+        }
+
         Activity activity = getActivity();
         WebView webView = getBridge().getWebView();
         final Float alphaToRestore = originalWebViewAlpha;
+        final Drawable webViewBackground = originalWebViewBackground;
+        final boolean webViewBackgroundCaptured = originalWebViewBackgroundCaptured;
         final Drawable parentBackground = originalWebViewParentBackground;
+        final boolean parentBackgroundCaptured = originalWebViewParentBackgroundCaptured;
         originalWebViewAlpha = null;
+        originalWebViewBackground = null;
+        originalWebViewBackgroundCaptured = false;
         originalWebViewParentBackground = null;
+        originalWebViewParentBackgroundCaptured = false;
+
+        if (alphaToRestore == null && !webViewBackgroundCaptured && !parentBackgroundCaptured) {
+            return;
+        }
 
         if (activity == null || webView == null) {
             return;
@@ -1802,7 +1903,12 @@ public class CameraPreview extends Plugin implements CameraXView.CameraXViewList
                 if (alphaToRestore != null) {
                     webView.setAlpha(alphaToRestore);
                 }
-                if (webViewParent != null && parentBackground != null) {
+                if (webViewBackgroundCaptured) {
+                    webView.setBackground(webViewBackground);
+                } else {
+                    webView.setBackgroundColor(DEFAULT_WEB_VIEW_BACKGROUND);
+                }
+                if (webViewParent != null && parentBackgroundCaptured) {
                     webViewParent.setBackground(parentBackground);
                 }
             } catch (Exception ignored) {}
@@ -2042,7 +2148,16 @@ public class CameraPreview extends Plugin implements CameraXView.CameraXViewList
     }
 
     @Override
-    public void onCameraStartError(String message) {
+    public void onCameraStartError(CameraXView source, String message) {
+        if (cameraXView != null && cameraXView != source) {
+            Log.d(TAG, "onCameraStartError: ignoring callback from stale instance");
+            return;
+        }
+        if (cameraXView == source) {
+            cameraXView = null;
+        }
+        toBackVisualStateActive = false;
+
         PluginCall call = bridge.getSavedCall(cameraStartCallbackId);
         if (call != null) {
             call.reject(message);
@@ -2051,24 +2166,7 @@ public class CameraPreview extends Plugin implements CameraXView.CameraXViewList
             resetPendingStartBarcodeScanner();
         }
 
-        // Restore original window background on error to prevent black screen
-        // Use synchronized block to ensure only one thread captures and clears the background.
-        // Even if multiple errors occur, only the first will have a non-null background to restore.
-        synchronized (this) {
-            final Drawable backgroundToRestore = originalWindowBackground;
-            if (backgroundToRestore != null) {
-                originalWindowBackground = null; // Clear immediately so other threads won't restore
-                getBridge()
-                    .getActivity()
-                    .runOnUiThread(() -> {
-                        try {
-                            getBridge().getActivity().getWindow().setBackgroundDrawable(backgroundToRestore);
-                        } catch (Exception e) {
-                            Log.w(TAG, "Failed to restore window background on error", e);
-                        }
-                    });
-            }
-        }
+        restoreOriginalWindowBackground(getBridge().getActivity());
         restoreWebViewVisualState();
         restoreSystemUiForToBackMode(getBridge().getActivity());
     }

--- a/android/src/main/java/app/capgo/capacitor/camera/preview/CameraXView.java
+++ b/android/src/main/java/app/capgo/capacitor/camera/preview/CameraXView.java
@@ -1640,7 +1640,6 @@ public class CameraXView implements LifecycleOwner, LifecycleObserver {
                     cameraProvider.bindToLifecycle(this, currentCameraSelector, barcodeAnalysis);
                     barcodeAnalysisBoundWithSession = false;
                 } else {
-                    barcodeAnalysis.clearAnalyzer();
                     barcodeAnalysis.setAnalyzer(cameraExecutor, this::analyzeBarcodeImage);
                 }
                 callback.onStarted();

--- a/android/src/main/java/app/capgo/capacitor/camera/preview/CameraXView.java
+++ b/android/src/main/java/app/capgo/capacitor/camera/preview/CameraXView.java
@@ -1290,8 +1290,11 @@ public class CameraXView implements LifecycleOwner, LifecycleObserver {
                             );
                             previewContainer.postDelayed(
                                 () -> {
-                                    if (!cameraStartedCallbackSent) {
-                                        notifyCameraStartedIfNeeded("fallback");
+                                    PreviewView.StreamState latestState = previewView != null
+                                        ? previewView.getPreviewStreamState().getValue()
+                                        : null;
+                                    if (!cameraStartedCallbackSent && latestState == PreviewView.StreamState.STREAMING) {
+                                        notifyCameraStartedIfNeeded("fallback-streaming");
                                     }
                                 },
                                 1500

--- a/android/src/main/java/app/capgo/capacitor/camera/preview/CameraXView.java
+++ b/android/src/main/java/app/capgo/capacitor/camera/preview/CameraXView.java
@@ -148,6 +148,7 @@ public class CameraXView implements LifecycleOwner, LifecycleObserver {
     private ImageCapture imageCapture;
     private ImageCapture sampleImageCapture;
     private ImageAnalysis barcodeAnalysis;
+    private boolean barcodeAnalysisBoundWithSession = false;
     private BarcodeScanner barcodeScanner;
     private VideoCapture<Recorder> videoCapture;
     private Recording currentRecording;
@@ -631,6 +632,8 @@ public class CameraXView implements LifecycleOwner, LifecycleObserver {
                 if (cameraProvider != null) {
                     cameraProvider.unbindAll();
                 }
+                barcodeAnalysis = null;
+                barcodeAnalysisBoundWithSession = false;
                 if (cameraExecutor != null) {
                     cameraExecutor.shutdown();
                 }
@@ -1077,8 +1080,9 @@ public class CameraXView implements LifecycleOwner, LifecycleObserver {
                     .build();
                 sampleImageCapture = imageCapture;
                 barcodeAnalysis = null;
+                barcodeAnalysisBoundWithSession = false;
 
-                if (!sessionConfig.isVideoModeEnabled()) {
+                if (!sessionConfig.isVideoModeEnabled() && sessionConfig.isBarcodeScannerEnabled()) {
                     barcodeAnalysis = createBarcodeAnalysisUseCase();
                     if (isBarcodeScannerActive && barcodeScanner != null && cameraExecutor != null) {
                         barcodeAnalysis.setAnalyzer(cameraExecutor, this::analyzeBarcodeImage);
@@ -1590,10 +1594,13 @@ public class CameraXView implements LifecycleOwner, LifecycleObserver {
     private void bindConfiguredUseCases(CameraBindingPlan bindingPlan, Preview preview) {
         if (sessionConfig.isVideoModeEnabled() && videoCapture != null) {
             camera = cameraProvider.bindToLifecycle(this, bindingPlan.selector, preview, imageCapture, videoCapture);
+            barcodeAnalysisBoundWithSession = false;
         } else if (barcodeAnalysis != null) {
             camera = cameraProvider.bindToLifecycle(this, bindingPlan.selector, preview, imageCapture, barcodeAnalysis);
+            barcodeAnalysisBoundWithSession = true;
         } else {
             camera = cameraProvider.bindToLifecycle(this, bindingPlan.selector, preview, imageCapture);
+            barcodeAnalysisBoundWithSession = false;
         }
 
         CameraInfo cameraInfo = camera.getCameraInfo();
@@ -1631,6 +1638,7 @@ public class CameraXView implements LifecycleOwner, LifecycleObserver {
                     barcodeAnalysis = createBarcodeAnalysisUseCase();
                     barcodeAnalysis.setAnalyzer(cameraExecutor, this::analyzeBarcodeImage);
                     cameraProvider.bindToLifecycle(this, currentCameraSelector, barcodeAnalysis);
+                    barcodeAnalysisBoundWithSession = false;
                 } else {
                     barcodeAnalysis.clearAnalyzer();
                     barcodeAnalysis.setAnalyzer(cameraExecutor, this::analyzeBarcodeImage);
@@ -1644,7 +1652,7 @@ public class CameraXView implements LifecycleOwner, LifecycleObserver {
     }
 
     public void stopBarcodeScanner() {
-        mainExecutor.execute(() -> stopBarcodeScannerInternal(false));
+        mainExecutor.execute(() -> stopBarcodeScannerInternal(true));
     }
 
     private ImageAnalysis createBarcodeAnalysisUseCase() {
@@ -1665,12 +1673,14 @@ public class CameraXView implements LifecycleOwner, LifecycleObserver {
 
         if (barcodeAnalysis != null) {
             barcodeAnalysis.clearAnalyzer();
-            if (unbindAnalysis && cameraProvider != null) {
+            if (unbindAnalysis && cameraProvider != null && !barcodeAnalysisBoundWithSession) {
                 try {
                     cameraProvider.unbind(barcodeAnalysis);
-                    barcodeAnalysis = null;
                 } catch (Exception e) {
                     Log.w(TAG, "stopBarcodeScannerInternal: failed to unbind barcode analysis", e);
+                } finally {
+                    barcodeAnalysis = null;
+                    barcodeAnalysisBoundWithSession = false;
                 }
             }
         }
@@ -1878,6 +1888,7 @@ public class CameraXView implements LifecycleOwner, LifecycleObserver {
         target.setCentered(source.isCentered());
         target.setTargetZoom(source.getTargetZoom());
         target.setEnablePhysicalDeviceSelection(source.isPhysicalDeviceSelectionEnabled());
+        target.setBarcodeScannerEnabled(source.isBarcodeScannerEnabled());
     }
 
     private void requestEnumeratedDeviceCacheRefresh() {

--- a/android/src/main/java/app/capgo/capacitor/camera/preview/CameraXView.java
+++ b/android/src/main/java/app/capgo/capacitor/camera/preview/CameraXView.java
@@ -129,7 +129,7 @@ public class CameraXView implements LifecycleOwner, LifecycleObserver {
         void onBarcodesScanned(JSONArray barcodes);
         void onBarcodeScanError(String message);
         void onCameraStarted(int width, int height, int x, int y);
-        void onCameraStartError(String message);
+        void onCameraStartError(CameraXView source, String message);
         void onCameraStopped(CameraXView source);
     }
 
@@ -191,6 +191,7 @@ public class CameraXView implements LifecycleOwner, LifecycleObserver {
     private volatile boolean isBarcodeFrameProcessing = false;
     private volatile long lastBarcodeFrameAtMs = 0L;
     private volatile long barcodeDetectionIntervalMs = 500L;
+    private boolean cameraStartedCallbackSent = false;
 
     // Operation coordination (acts like a semaphore to prevent stop during active ops)
     private final Object operationLock = new Object();
@@ -481,13 +482,13 @@ public class CameraXView implements LifecycleOwner, LifecycleObserver {
             // runnable is still queued — never transition backward from DESTROYED.
             if (lifecycleRegistry.getCurrentState() == Lifecycle.State.DESTROYED) {
                 if (listener != null) {
-                    listener.onCameraStartError("Camera start aborted: lifecycle destroyed");
+                    listener.onCameraStartError(this, "Camera start aborted: lifecycle destroyed");
                 }
                 return;
             }
             if (stopRequested) {
                 if (listener != null) {
-                    listener.onCameraStartError("Camera start aborted: stop requested");
+                    listener.onCameraStartError(this, "Camera start aborted: stop requested");
                 }
                 return;
             }
@@ -496,44 +497,45 @@ public class CameraXView implements LifecycleOwner, LifecycleObserver {
                 lifecycleRegistry.setCurrentState(Lifecycle.State.CREATED);
                 if (lifecycleRegistry.getCurrentState() == Lifecycle.State.DESTROYED) {
                     if (listener != null) {
-                        listener.onCameraStartError("Camera start aborted: lifecycle destroyed");
+                        listener.onCameraStartError(this, "Camera start aborted: lifecycle destroyed");
                     }
                     return;
                 }
                 if (stopRequested) {
                     if (listener != null) {
-                        listener.onCameraStartError("Camera start aborted: stop requested");
+                        listener.onCameraStartError(this, "Camera start aborted: stop requested");
                     }
                     return;
                 }
             }
             if (lifecycleRegistry.getCurrentState() == Lifecycle.State.DESTROYED) {
                 if (listener != null) {
-                    listener.onCameraStartError("Camera start aborted: lifecycle destroyed");
+                    listener.onCameraStartError(this, "Camera start aborted: lifecycle destroyed");
                 }
                 return;
             }
             if (stopRequested) {
                 if (listener != null) {
-                    listener.onCameraStartError("Camera start aborted: stop requested");
+                    listener.onCameraStartError(this, "Camera start aborted: stop requested");
                 }
                 return;
             }
             lifecycleRegistry.setCurrentState(Lifecycle.State.STARTED);
             if (lifecycleRegistry.getCurrentState() == Lifecycle.State.DESTROYED) {
                 if (listener != null) {
-                    listener.onCameraStartError("Camera start aborted: lifecycle destroyed");
+                    listener.onCameraStartError(this, "Camera start aborted: lifecycle destroyed");
                 }
                 return;
             }
             if (stopRequested) {
                 if (listener != null) {
-                    listener.onCameraStartError("Camera start aborted: stop requested");
+                    listener.onCameraStartError(this, "Camera start aborted: stop requested");
                 }
                 return;
             }
 
             this.sessionConfig = config;
+            cameraStartedCallbackSent = false;
             cameraExecutor = Executors.newSingleThreadExecutor();
             requestEnumeratedDeviceCacheRefresh();
 
@@ -654,7 +656,7 @@ public class CameraXView implements LifecycleOwner, LifecycleObserver {
     private void restoreWebViewBackground() {
         // Capture sessionConfig reference once to avoid race conditions
         CameraSessionConfiguration config = sessionConfig;
-        boolean shouldRestore = config != null && config.isToBack();
+        boolean shouldRestore = config == null || !config.isToBack();
         if (shouldRestore) {
             // Capture background color before posting to UI thread
             final int backgroundColorToRestore = originalWebViewBackground;
@@ -674,26 +676,26 @@ public class CameraXView implements LifecycleOwner, LifecycleObserver {
                 try {
                     if (lifecycleRegistry.getCurrentState() == Lifecycle.State.DESTROYED) {
                         if (listener != null) {
-                            listener.onCameraStartError("Camera binding cancelled: lifecycle destroyed (before provider)");
+                            listener.onCameraStartError(this, "Camera binding cancelled: lifecycle destroyed (before provider)");
                         }
                         return;
                     }
                     if (stopRequested) {
                         if (listener != null) {
-                            listener.onCameraStartError("Camera binding cancelled: stop requested (before provider)");
+                            listener.onCameraStartError(this, "Camera binding cancelled: stop requested (before provider)");
                         }
                         return;
                     }
                     cameraProvider = cameraProviderFuture.get();
                     if (lifecycleRegistry.getCurrentState() == Lifecycle.State.DESTROYED) {
                         if (listener != null) {
-                            listener.onCameraStartError("Camera binding cancelled: lifecycle destroyed (after provider)");
+                            listener.onCameraStartError(this, "Camera binding cancelled: lifecycle destroyed (after provider)");
                         }
                         return;
                     }
                     if (stopRequested) {
                         if (listener != null) {
-                            listener.onCameraStartError("Camera binding cancelled: stop requested (after provider)");
+                            listener.onCameraStartError(this, "Camera binding cancelled: stop requested (after provider)");
                         }
                         return;
                     }
@@ -703,7 +705,7 @@ public class CameraXView implements LifecycleOwner, LifecycleObserver {
                     // Restore webView background on error
                     restoreWebViewBackground();
                     if (listener != null) {
-                        listener.onCameraStartError("Error initializing camera: " + e.getMessage());
+                        listener.onCameraStartError(this, "Error initializing camera: " + e.getMessage());
                     }
                 }
             },
@@ -715,13 +717,11 @@ public class CameraXView implements LifecycleOwner, LifecycleObserver {
         if (previewView != null) {
             removePreviewView();
         }
-        if (sessionConfig.isToBack()) {
-            // Set to black initially to prevent flickering, will be transparent after camera starts
-            webView.setBackgroundColor(android.graphics.Color.BLACK);
-        }
-
         // Create a container to hold both the preview and grid overlay
         previewContainer = new FrameLayout(context);
+        if (sessionConfig != null && sessionConfig.isToBack()) {
+            previewContainer.setBackgroundColor(Color.TRANSPARENT);
+        }
         // Ensure container can receive touch events
         previewContainer.setClickable(true);
         previewContainer.setFocusable(true);
@@ -735,9 +735,11 @@ public class CameraXView implements LifecycleOwner, LifecycleObserver {
 
         // Create and setup the preview view
         previewView = new PreviewView(context);
-        // Use TextureView-backed implementation for broader device compatibility when overlaying with WebView
-        // This avoids SurfaceView z-order issues seen on some MIUI/EMUI devices.
-        previewView.setImplementationMode(PreviewView.ImplementationMode.COMPATIBLE);
+        if (sessionConfig != null && sessionConfig.isToBack()) {
+            previewView.setBackgroundColor(Color.TRANSPARENT);
+        }
+        PreviewView.ImplementationMode implementationMode = choosePreviewImplementationMode();
+        previewView.setImplementationMode(implementationMode);
         // Set scale type based on aspectMode: 'contain' uses FIT, 'cover' uses FILL
         String aspectMode = sessionConfig != null ? sessionConfig.getAspectMode() : "contain";
         previewView.setScaleType("cover".equals(aspectMode) ? PreviewView.ScaleType.FILL_CENTER : PreviewView.ScaleType.FIT_CENTER);
@@ -752,6 +754,14 @@ public class CameraXView implements LifecycleOwner, LifecycleObserver {
             previewView,
             new FrameLayout.LayoutParams(FrameLayout.LayoutParams.MATCH_PARENT, FrameLayout.LayoutParams.MATCH_PARENT)
         );
+
+        previewView
+            .getPreviewStreamState()
+            .observe(this, (streamState) -> {
+                if (sessionConfig != null && sessionConfig.isToBack() && streamState == PreviewView.StreamState.STREAMING) {
+                    notifyCameraStartedIfNeeded("streaming");
+                }
+            });
 
         // Create and setup the grid overlay
         gridOverlayView = new GridOverlayView(context);
@@ -781,7 +791,17 @@ public class CameraXView implements LifecycleOwner, LifecycleObserver {
         if (parent != null) {
             FrameLayout.LayoutParams layoutParams = calculatePreviewLayoutParams();
             parent.addView(previewContainer, layoutParams);
-            if (sessionConfig.isToBack()) webView.bringToFront();
+            if (sessionConfig.isToBack()) {
+                webView.bringToFront();
+                parent.requestTransparentRegion(webView);
+                webView.post(() -> {
+                    webView.bringToFront();
+                    ViewGroup currentParent = (ViewGroup) webView.getParent();
+                    if (currentParent != null) {
+                        currentParent.requestTransparentRegion(webView);
+                    }
+                });
+            }
 
             // Log the actual position after layout
             previewContainer.post(() -> {
@@ -809,6 +829,10 @@ public class CameraXView implements LifecycleOwner, LifecycleObserver {
                 Log.d(TAG, "========================");
             });
         }
+    }
+
+    private PreviewView.ImplementationMode choosePreviewImplementationMode() {
+        return PreviewView.ImplementationMode.COMPATIBLE;
     }
 
     /**
@@ -1000,7 +1024,9 @@ public class CameraXView implements LifecycleOwner, LifecycleObserver {
         if (focusIndicatorView != null) {
             focusIndicatorView = null;
         }
-        webView.setBackgroundColor(originalWebViewBackground);
+        if (sessionConfig == null || !sessionConfig.isToBack()) {
+            webView.setBackgroundColor(originalWebViewBackground);
+        }
     }
 
     @OptIn(markerClass = ExperimentalCamera2Interop.class)
@@ -1050,6 +1076,14 @@ public class CameraXView implements LifecycleOwner, LifecycleObserver {
                     .setTargetRotation(rotation)
                     .build();
                 sampleImageCapture = imageCapture;
+                barcodeAnalysis = null;
+
+                if (!sessionConfig.isVideoModeEnabled()) {
+                    barcodeAnalysis = createBarcodeAnalysisUseCase();
+                    if (isBarcodeScannerActive && barcodeScanner != null && cameraExecutor != null) {
+                        barcodeAnalysis.setAnalyzer(cameraExecutor, this::analyzeBarcodeImage);
+                    }
+                }
 
                 // Only setup VideoCapture if enableVideoMode is true
                 if (sessionConfig.isVideoModeEnabled()) {
@@ -1214,6 +1248,7 @@ public class CameraXView implements LifecycleOwner, LifecycleObserver {
                         if (initialZoom < minZoom || initialZoom > maxZoom) {
                             if (listener != null) {
                                 listener.onCameraStartError(
+                                    this,
                                     "Initial zoom level " +
                                         initialZoom +
                                         " is not available. " +
@@ -1233,40 +1268,72 @@ public class CameraXView implements LifecycleOwner, LifecycleObserver {
                 isRunning = true;
                 Log.d(TAG, "bindCameraUseCases: Camera bound successfully");
                 if (listener != null) {
-                    // Post the callback to ensure layout is complete
-                    previewContainer.post(() -> {
-                        // Return actual preview container dimensions instead of requested dimensions
-                        // Get the actual camera dimensions and position
-                        int actualWidth = getPreviewWidth();
-                        int actualHeight = getPreviewHeight();
-                        int actualX = getPreviewX();
-                        int actualY = getPreviewY();
-
-                        Log.d(
-                            TAG,
-                            "onCameraStarted callback - actualX=" +
-                                actualX +
-                                ", actualY=" +
-                                actualY +
-                                ", actualWidth=" +
-                                actualWidth +
-                                ", actualHeight=" +
-                                actualHeight
-                        );
-
-                        // Update grid overlay bounds after camera is started
-                        updateGridOverlayBounds();
-
-                        // Notify listener that camera is started
-                        // The listener (CameraPreview) will handle setting both window and webview to transparent
-                        listener.onCameraStarted(actualWidth, actualHeight, actualX, actualY);
-                    });
+                    if (sessionConfig != null && sessionConfig.isToBack()) {
+                        PreviewView.StreamState streamState = previewView != null ? previewView.getPreviewStreamState().getValue() : null;
+                        if (streamState == PreviewView.StreamState.STREAMING) {
+                            notifyCameraStartedIfNeeded("already-streaming");
+                        } else if (previewContainer != null) {
+                            previewContainer.postDelayed(
+                                () -> {
+                                    PreviewView.StreamState latestState = previewView != null
+                                        ? previewView.getPreviewStreamState().getValue()
+                                        : null;
+                                    if (latestState == PreviewView.StreamState.STREAMING) {
+                                        notifyCameraStartedIfNeeded("watchdog-streaming");
+                                    }
+                                },
+                                300
+                            );
+                            previewContainer.postDelayed(
+                                () -> {
+                                    if (!cameraStartedCallbackSent) {
+                                        notifyCameraStartedIfNeeded("fallback");
+                                    }
+                                },
+                                1500
+                            );
+                        }
+                    } else {
+                        notifyCameraStartedIfNeeded("bound");
+                    }
                 }
             } catch (Exception e) {
                 // Restore webView background on error
                 restoreWebViewBackground();
-                if (listener != null) listener.onCameraStartError("Error binding camera: " + e.getMessage());
+                if (listener != null) listener.onCameraStartError(this, "Error binding camera: " + e.getMessage());
             }
+        });
+    }
+
+    private void notifyCameraStartedIfNeeded(String reason) {
+        if (cameraStartedCallbackSent || listener == null || previewContainer == null) {
+            return;
+        }
+        cameraStartedCallbackSent = true;
+        previewContainer.post(() -> {
+            if (listener == null || previewContainer == null) {
+                return;
+            }
+
+            int actualWidth = getPreviewWidth();
+            int actualHeight = getPreviewHeight();
+            int actualX = getPreviewX();
+            int actualY = getPreviewY();
+
+            Log.d(
+                TAG,
+                "onCameraStarted callback - actualX=" +
+                    actualX +
+                    ", actualY=" +
+                    actualY +
+                    ", actualWidth=" +
+                    actualWidth +
+                    ", actualHeight=" +
+                    actualHeight
+            );
+
+            updateGridOverlayBounds();
+            listener.onCameraStarted(actualWidth, actualHeight, actualX, actualY);
         });
     }
 
@@ -1523,6 +1590,8 @@ public class CameraXView implements LifecycleOwner, LifecycleObserver {
     private void bindConfiguredUseCases(CameraBindingPlan bindingPlan, Preview preview) {
         if (sessionConfig.isVideoModeEnabled() && videoCapture != null) {
             camera = cameraProvider.bindToLifecycle(this, bindingPlan.selector, preview, imageCapture, videoCapture);
+        } else if (barcodeAnalysis != null) {
+            camera = cameraProvider.bindToLifecycle(this, bindingPlan.selector, preview, imageCapture, barcodeAnalysis);
         } else {
             camera = cameraProvider.bindToLifecycle(this, bindingPlan.selector, preview, imageCapture);
         }
@@ -1551,26 +1620,21 @@ public class CameraXView implements LifecycleOwner, LifecycleObserver {
 
         mainExecutor.execute(() -> {
             try {
-                stopBarcodeScannerInternal(true);
+                stopBarcodeScannerInternal(false);
                 barcodeScanner = createBarcodeScanner(formats);
                 barcodeDetectionIntervalMs = Math.max(100L, detectionIntervalMs);
                 lastBarcodeFrameAtMs = 0L;
                 isBarcodeFrameProcessing = false;
                 isBarcodeScannerActive = true;
 
-                ResolutionSelector barcodeResolutionSelector = new ResolutionSelector.Builder()
-                    .setResolutionStrategy(
-                        new ResolutionStrategy(new Size(1280, 720), ResolutionStrategy.FALLBACK_RULE_CLOSEST_LOWER_THEN_HIGHER)
-                    )
-                    .build();
-
-                barcodeAnalysis = new ImageAnalysis.Builder()
-                    .setBackpressureStrategy(ImageAnalysis.STRATEGY_KEEP_ONLY_LATEST)
-                    .setResolutionSelector(barcodeResolutionSelector)
-                    .build();
-                barcodeAnalysis.setAnalyzer(cameraExecutor, this::analyzeBarcodeImage);
-
-                cameraProvider.bindToLifecycle(this, currentCameraSelector, barcodeAnalysis);
+                if (barcodeAnalysis == null) {
+                    barcodeAnalysis = createBarcodeAnalysisUseCase();
+                    barcodeAnalysis.setAnalyzer(cameraExecutor, this::analyzeBarcodeImage);
+                    cameraProvider.bindToLifecycle(this, currentCameraSelector, barcodeAnalysis);
+                } else {
+                    barcodeAnalysis.clearAnalyzer();
+                    barcodeAnalysis.setAnalyzer(cameraExecutor, this::analyzeBarcodeImage);
+                }
                 callback.onStarted();
             } catch (Exception e) {
                 stopBarcodeScannerInternal(true);
@@ -1580,7 +1644,18 @@ public class CameraXView implements LifecycleOwner, LifecycleObserver {
     }
 
     public void stopBarcodeScanner() {
-        mainExecutor.execute(() -> stopBarcodeScannerInternal(true));
+        mainExecutor.execute(() -> stopBarcodeScannerInternal(false));
+    }
+
+    private ImageAnalysis createBarcodeAnalysisUseCase() {
+        ResolutionSelector barcodeResolutionSelector = new ResolutionSelector.Builder()
+            .setResolutionStrategy(new ResolutionStrategy(new Size(1280, 720), ResolutionStrategy.FALLBACK_RULE_CLOSEST_LOWER_THEN_HIGHER))
+            .build();
+
+        return new ImageAnalysis.Builder()
+            .setBackpressureStrategy(ImageAnalysis.STRATEGY_KEEP_ONLY_LATEST)
+            .setResolutionSelector(barcodeResolutionSelector)
+            .build();
     }
 
     private void stopBarcodeScannerInternal(boolean unbindAnalysis) {
@@ -1593,11 +1668,11 @@ public class CameraXView implements LifecycleOwner, LifecycleObserver {
             if (unbindAnalysis && cameraProvider != null) {
                 try {
                     cameraProvider.unbind(barcodeAnalysis);
+                    barcodeAnalysis = null;
                 } catch (Exception e) {
                     Log.w(TAG, "stopBarcodeScannerInternal: failed to unbind barcode analysis", e);
                 }
             }
-            barcodeAnalysis = null;
         }
 
         if (barcodeScanner != null) {

--- a/android/src/main/java/app/capgo/capacitor/camera/preview/CameraXView.java
+++ b/android/src/main/java/app/capgo/capacitor/camera/preview/CameraXView.java
@@ -148,7 +148,6 @@ public class CameraXView implements LifecycleOwner, LifecycleObserver {
     private ImageCapture imageCapture;
     private ImageCapture sampleImageCapture;
     private ImageAnalysis barcodeAnalysis;
-    private boolean barcodeAnalysisBoundWithSession = false;
     private BarcodeScanner barcodeScanner;
     private VideoCapture<Recorder> videoCapture;
     private Recording currentRecording;
@@ -633,7 +632,6 @@ public class CameraXView implements LifecycleOwner, LifecycleObserver {
                     cameraProvider.unbindAll();
                 }
                 barcodeAnalysis = null;
-                barcodeAnalysisBoundWithSession = false;
                 if (cameraExecutor != null) {
                     cameraExecutor.shutdown();
                 }
@@ -1080,7 +1078,6 @@ public class CameraXView implements LifecycleOwner, LifecycleObserver {
                     .build();
                 sampleImageCapture = imageCapture;
                 barcodeAnalysis = null;
-                barcodeAnalysisBoundWithSession = false;
 
                 if (!sessionConfig.isVideoModeEnabled() && sessionConfig.isBarcodeScannerEnabled()) {
                     barcodeAnalysis = createBarcodeAnalysisUseCase();
@@ -1597,13 +1594,10 @@ public class CameraXView implements LifecycleOwner, LifecycleObserver {
     private void bindConfiguredUseCases(CameraBindingPlan bindingPlan, Preview preview) {
         if (sessionConfig.isVideoModeEnabled() && videoCapture != null) {
             camera = cameraProvider.bindToLifecycle(this, bindingPlan.selector, preview, imageCapture, videoCapture);
-            barcodeAnalysisBoundWithSession = false;
         } else if (barcodeAnalysis != null) {
             camera = cameraProvider.bindToLifecycle(this, bindingPlan.selector, preview, imageCapture, barcodeAnalysis);
-            barcodeAnalysisBoundWithSession = true;
         } else {
             camera = cameraProvider.bindToLifecycle(this, bindingPlan.selector, preview, imageCapture);
-            barcodeAnalysisBoundWithSession = false;
         }
 
         CameraInfo cameraInfo = camera.getCameraInfo();
@@ -1641,7 +1635,6 @@ public class CameraXView implements LifecycleOwner, LifecycleObserver {
                     barcodeAnalysis = createBarcodeAnalysisUseCase();
                     barcodeAnalysis.setAnalyzer(cameraExecutor, this::analyzeBarcodeImage);
                     cameraProvider.bindToLifecycle(this, currentCameraSelector, barcodeAnalysis);
-                    barcodeAnalysisBoundWithSession = false;
                 } else {
                     barcodeAnalysis.setAnalyzer(cameraExecutor, this::analyzeBarcodeImage);
                 }
@@ -1675,14 +1668,13 @@ public class CameraXView implements LifecycleOwner, LifecycleObserver {
 
         if (barcodeAnalysis != null) {
             barcodeAnalysis.clearAnalyzer();
-            if (unbindAnalysis && cameraProvider != null && !barcodeAnalysisBoundWithSession) {
+            if (unbindAnalysis && cameraProvider != null) {
                 try {
                     cameraProvider.unbind(barcodeAnalysis);
                 } catch (Exception e) {
                     Log.w(TAG, "stopBarcodeScannerInternal: failed to unbind barcode analysis", e);
                 } finally {
                     barcodeAnalysis = null;
-                    barcodeAnalysisBoundWithSession = false;
                 }
             }
         }

--- a/android/src/main/java/app/capgo/capacitor/camera/preview/model/CameraSessionConfiguration.java
+++ b/android/src/main/java/app/capgo/capacitor/camera/preview/model/CameraSessionConfiguration.java
@@ -27,6 +27,7 @@ public class CameraSessionConfiguration {
     private boolean isCentered = false;
     private final String videoQuality;
     private boolean enablePhysicalDeviceSelection = false;
+    private boolean barcodeScannerEnabled = false;
 
     public CameraSessionConfiguration(
         String deviceId,
@@ -156,6 +157,14 @@ public class CameraSessionConfiguration {
 
     public void setEnablePhysicalDeviceSelection(boolean enablePhysicalDeviceSelection) {
         this.enablePhysicalDeviceSelection = enablePhysicalDeviceSelection;
+    }
+
+    public boolean isBarcodeScannerEnabled() {
+        return barcodeScannerEnabled;
+    }
+
+    public void setBarcodeScannerEnabled(boolean barcodeScannerEnabled) {
+        this.barcodeScannerEnabled = barcodeScannerEnabled;
     }
 
     // Additional getters with "get" prefix for compatibility


### PR DESCRIPTION
## What
- Fix Android `toBack` camera preview flicker by removing the black-background transition and deferring WebView transparency until the preview stream is ready.
- Keep the full window/parent/WebView transparency workaround scoped to Huawei/Honor/Xiaomi-style devices.
- Avoid restoring the WebView background while an active `toBack` session owns the transparent state.
- Bind barcode analysis with the initial CameraX use cases so starting the scanner does not rebind/restart the camera graph.

## Why
- Pixel 9a on Android 17 was flashing black/white because native backgrounds were changed before CameraX had a live preview surface.
- The broad full-stack transparency workaround is still needed for some OEM compositor behavior, but applying it to Pixel exposed the flicker.

## How
- Capture original window/WebView/parent visual state and restore it only when the session really stops or fails.
- Apply WebView transparency from the CameraX start callback after the preview stream reports ready.
- Keep `PreviewView` in `COMPATIBLE` mode and use transparent preview/container backgrounds for `toBack` startup.

## Testing
- CI will run full verification on this PR.

## Not Tested
- Not manually validated on the Pixel 9a device in this branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved transparent-background overlay for "toBack" camera previews with robust capture/restore of window and WebView visuals.
  * Configurable barcode scanner toggle with improved scanner lifecycle and reuse.

* **Bug Fixes**
  * Safer camera start/error handling that ignores stale sessions and adds retry watchdogs.
  * More reliable restoration of WebView and system UI state across camera lifecycle events.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->