### PR TITLE
feat: granular video recording options (closes #366)

### DIFF
--- a/README.md
+++ b/README.md
@@ -376,6 +376,12 @@ Documentation for the [uploader](https://github.com/Cap-go/capacitor-uploader)
 * [`setOpacity(...)`](#setopacity)
 * [`stopRecordVideo()`](#stoprecordvideo)
 * [`startRecordVideo(...)`](#startrecordvideo)
+* [`setVideoQuality(...)`](#setvideoquality)
+* [`getVideoQuality()`](#getvideoquality)
+* [`getSupportedVideoQualities()`](#getsupportedvideoqualities)
+* [`setVideoCodec(...)`](#setvideocodec)
+* [`getVideoCodec()`](#getvideocodec)
+* [`getSupportedVideoCodecs()`](#getsupportedvideocodecs)
 * [`isRunning()`](#isrunning)
 * [`getAvailableDevices()`](#getavailabledevices)
 * [`getZoom()`](#getzoom)
@@ -392,6 +398,7 @@ Documentation for the [uploader](https://github.com/Cap-go/capacitor-uploader)
 * [`addListener('orientationChange', ...)`](#addlistenerorientationchange-)
 * [`addListener('barcodeScanned', ...)`](#addlistenerbarcodescanned-)
 * [`addListener('barcodeScanError', ...)`](#addlistenerbarcodescanerror-)
+* [`addListener('recordingFinished', ...)`](#addlistenerrecordingfinished-)
 * [`deleteFile(...)`](#deletefile)
 * [`getSafeAreaInsets()`](#getsafeareainsets)
 * [`getOrientation()`](#getorientation)
@@ -728,12 +735,12 @@ Sets the opacity of the camera preview.
 ### stopRecordVideo()
 
 ```typescript
-stopRecordVideo() => Promise<{ videoFilePath: string; }>
+stopRecordVideo() => Promise<RecordingFinishedEvent>
 ```
 
 Stops an ongoing video recording.
 
-**Returns:** <code>Promise&lt;{ videoFilePath: string; }&gt;</code>
+**Returns:** <code>Promise&lt;<a href="#recordingfinishedevent">RecordingFinishedEvent</a>&gt;</code>
 
 **Since:** 0.0.1
 
@@ -748,11 +755,105 @@ startRecordVideo(options: CameraPreviewOptions) => Promise<void>
 
 Starts recording a video.
 
-| Param         | Type                                                                  | Description                                  |
-| ------------- | --------------------------------------------------------------------- | -------------------------------------------- |
-| **`options`** | <code><a href="#camerapreviewoptions">CameraPreviewOptions</a></code> | - The options for video recording. Only iOS. |
+| Param         | Type                                                                  | Description                        |
+| ------------- | --------------------------------------------------------------------- | ---------------------------------- |
+| **`options`** | <code><a href="#camerapreviewoptions">CameraPreviewOptions</a></code> | - The options for video recording. |
 
 **Since:** 0.0.1
+
+--------------------
+
+
+### setVideoQuality(...)
+
+```typescript
+setVideoQuality(options: { quality: VideoQuality; }) => Promise<void>
+```
+
+Sets the video recording quality for the active camera session.
+
+| Param         | Type                                                                | Description                  |
+| ------------- | ------------------------------------------------------------------- | ---------------------------- |
+| **`options`** | <code>{ quality: <a href="#videoquality">VideoQuality</a>; }</code> | - The desired video quality. |
+
+**Since:** 8.5.0
+
+--------------------
+
+
+### getVideoQuality()
+
+```typescript
+getVideoQuality() => Promise<{ quality: VideoQuality; }>
+```
+
+Gets the current video recording quality.
+
+**Returns:** <code>Promise&lt;{ quality: <a href="#videoquality">VideoQuality</a>; }&gt;</code>
+
+**Since:** 8.5.0
+
+--------------------
+
+
+### getSupportedVideoQualities()
+
+```typescript
+getSupportedVideoQualities() => Promise<{ qualities: VideoQuality[]; }>
+```
+
+Returns the video qualities supported by the active camera.
+
+**Returns:** <code>Promise&lt;{ qualities: VideoQuality[]; }&gt;</code>
+
+**Since:** 8.5.0
+
+--------------------
+
+
+### setVideoCodec(...)
+
+```typescript
+setVideoCodec(options: { codec: VideoCodec; }) => Promise<void>
+```
+
+Sets the video codec used when recording.
+
+| Param         | Type                                                          | Description          |
+| ------------- | ------------------------------------------------------------- | -------------------- |
+| **`options`** | <code>{ codec: <a href="#videocodec">VideoCodec</a>; }</code> | - The desired codec. |
+
+**Since:** 8.5.0
+
+--------------------
+
+
+### getVideoCodec()
+
+```typescript
+getVideoCodec() => Promise<{ codec: VideoCodec; }>
+```
+
+Gets the current video codec used for recording.
+
+**Returns:** <code>Promise&lt;{ codec: <a href="#videocodec">VideoCodec</a>; }&gt;</code>
+
+**Since:** 8.5.0
+
+--------------------
+
+
+### getSupportedVideoCodecs()
+
+```typescript
+getSupportedVideoCodecs() => Promise<{ codecs: VideoCodec[]; }>
+```
+
+Returns the video codecs supported by the active camera.
+
+**Returns:** <code>Promise&lt;{ codecs: VideoCodec[]; }&gt;</code>
+
+**Since:** 8.5.0
 
 --------------------
 
@@ -1031,6 +1132,26 @@ Adds a listener for non-fatal barcode scanner errors.
 --------------------
 
 
+### addListener('recordingFinished', ...)
+
+```typescript
+addListener(eventName: 'recordingFinished', listenerFunc: (data: RecordingFinishedEvent) => void) => Promise<PluginListenerHandle>
+```
+
+Adds a listener fired when a video recording finishes natively, including automatic stops.
+
+| Param              | Type                                                                                         |
+| ------------------ | -------------------------------------------------------------------------------------------- |
+| **`eventName`**    | <code>'recordingFinished'</code>                                                             |
+| **`listenerFunc`** | <code>(data: <a href="#recordingfinishedevent">RecordingFinishedEvent</a>) =&gt; void</code> |
+
+**Returns:** <code>Promise&lt;<a href="#pluginlistenerhandle">PluginListenerHandle</a>&gt;</code>
+
+**Since:** 8.4.7
+
+--------------------
+
+
 ### deleteFile(...)
 
 ```typescript
@@ -1218,7 +1339,10 @@ Defines the configuration options for starting the camera preview.
 | **`positioning`**                   | <code><a href="#camerapositioning">CameraPositioning</a></code>                    | The vertical positioning of the camera preview.                                                                                                                                                                                     | <code>"center"</code>  | 2.3.0  |
 | **`enableVideoMode`**               | <code>boolean</code>                                                               | If true, enables video capture capabilities when the camera starts.                                                                                                                                                                 | <code>false</code>     | 7.11.0 |
 | **`force`**                         | <code>boolean</code>                                                               | If true, forces the camera to start/restart even if it's already running or busy. This will kill the current camera session and start a new one, ignoring all state checks.                                                         | <code>false</code>     |        |
-| **`videoQuality`**                  | <code>'low' \| 'medium' \| 'high'</code>                                           | Sets the quality of video for recording. Options: 'low', 'medium', 'high'                                                                                                                                                           | <code>"high"</code>    |        |
+| **`videoQuality`**                  | <code><a href="#videoquality">VideoQuality</a></code>                              | Sets the quality of video for recording. Options: 'low', 'medium', 'high', '2160p', '1080p', '720p', '480p', '4:3'                                                                                                                  | <code>"high"</code>    |        |
+| **`maxDuration`**                   | <code>number</code>                                                                | Maximum recording duration in seconds. Recording stops automatically when reached.                                                                                                                                                  |                        |        |
+| **`maxFileSize`**                   | <code>number</code>                                                                | Maximum recording file size in bytes. Recording stops automatically when reached.                                                                                                                                                   |                        |        |
+| **`videoCodec`**                    | <code><a href="#videocodec">VideoCodec</a></code>                                  | Preferred video codec for recording.                                                                                                                                                                                                | <code>"avc1"</code>    |        |
 | **`barcodeScanner`**                | <code>boolean \| <a href="#barcodescanneroptions">BarcodeScannerOptions</a></code> | Starts barcode scanning together with the camera preview. Set to `true` or pass options to scan all supported formats. Omit this option to keep barcode scanning disabled at startup.                                               |                        | 8.8.0  |
 
 
@@ -1308,6 +1432,14 @@ Defines the options for setting the camera preview's opacity.
 | Prop          | Type                | Description                                                                 | Default          |
 | ------------- | ------------------- | --------------------------------------------------------------------------- | ---------------- |
 | **`opacity`** | <code>number</code> | The opacity percentage, from 0.0 (fully transparent) to 1.0 (fully opaque). | <code>1.0</code> |
+
+
+#### RecordingFinishedEvent
+
+| Prop                | Type                                                                        | Description                          |
+| ------------------- | --------------------------------------------------------------------------- | ------------------------------------ |
+| **`videoFilePath`** | <code>string</code>                                                         | The path to the recorded video file. |
+| **`reason`**        | <code><a href="#recordingfinishedreason">RecordingFinishedReason</a></code> | Why the recording stopped.           |
 
 
 #### CameraDevice
@@ -1417,6 +1549,20 @@ iOS: Values are expressed in physical pixels and exclude status bar.
 <code>'center' | 'top' | 'bottom'</code>
 
 
+#### VideoQuality
+
+<code>'low' | 'medium' | 'high' | '2160p' | '1080p' | '720p' | '480p' | '4:3'</code>
+
+
+#### VideoCodec
+
+Video codec identifiers used when recording.
+- `avc1`: H.264
+- `hvc1`: HEVC / H.265
+
+<code>'avc1' | 'hvc1' | 'jpeg' | 'apcn' | 'ap4h'</code>
+
+
 #### BarcodeScannerFormat
 
 <code>'aztec' | 'codabar' | 'code_39' | 'code_93' | 'code_128' | 'data_matrix' | 'ean_8' | 'ean_13' | 'itf' | 'pdf417' | 'qr_code' | 'upc_a' | 'upc_e'</code>
@@ -1445,6 +1591,11 @@ The available flash modes for the camera.
 From T, pick a set of properties whose keys are in the union K
 
 <code>{ [P in K]: T[P]; }</code>
+
+
+#### RecordingFinishedReason
+
+<code>'manual' | 'maxDuration' | 'maxFileSize'</code>
 
 
 #### FlashMode

--- a/android/src/main/java/app/capgo/capacitor/camera/preview/CameraPreview.java
+++ b/android/src/main/java/app/capgo/capacitor/camera/preview/CameraPreview.java
@@ -2691,9 +2691,7 @@ public class CameraPreview extends Plugin implements CameraXView.CameraXViewList
 
     @PluginMethod
     public void getSupportedVideoCodecs(PluginCall call) {
-        List<String> codecs = cameraXView != null
-            ? cameraXView.getSupportedVideoCodecs()
-            : Arrays.asList("avc1");
+        List<String> codecs = cameraXView != null ? cameraXView.getSupportedVideoCodecs() : Arrays.asList("avc1");
         JSONArray arr = new JSONArray();
         for (String codec : codecs) {
             arr.put(codec);
@@ -2702,7 +2700,6 @@ public class CameraPreview extends Plugin implements CameraXView.CameraXViewList
         ret.put("codecs", arr);
         call.resolve(ret);
     }
-
 
     @PluginMethod
     public void startRecordVideo(PluginCall call) {

--- a/android/src/main/java/app/capgo/capacitor/camera/preview/CameraPreview.java
+++ b/android/src/main/java/app/capgo/capacitor/camera/preview/CameraPreview.java
@@ -51,6 +51,7 @@ import com.getcapacitor.annotation.PermissionCallback;
 import com.google.android.gms.location.FusedLocationProviderClient;
 import com.google.android.gms.location.LocationServices;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
@@ -2373,6 +2374,14 @@ public class CameraPreview extends Plugin implements CameraXView.CameraXViewList
     }
 
     @Override
+    public void onVideoRecordingFinished(String filePath, String reason) {
+        JSObject data = new JSObject();
+        data.put("videoFilePath", filePath);
+        data.put("reason", reason);
+        notifyListeners("recordingFinished", data);
+    }
+
+    @Override
     public void onCameraStartError(CameraXView source, String message) {
         if (cameraXView != null && cameraXView != source) {
             Log.d(TAG, "onCameraStartError: ignoring callback from stale instance");
@@ -2603,6 +2612,99 @@ public class CameraPreview extends Plugin implements CameraXView.CameraXViewList
     }
 
     @PluginMethod
+    public void setVideoQuality(PluginCall call) {
+        if (cameraXView == null || !cameraXView.isRunning()) {
+            call.reject("Camera is not running");
+            return;
+        }
+        String quality = call.getString("quality");
+        if (quality == null) {
+            call.reject("quality is required");
+            return;
+        }
+        try {
+            cameraXView.setVideoQualitySetting(quality);
+            call.resolve();
+        } catch (IllegalArgumentException e) {
+            call.reject(e.getMessage());
+        } catch (Exception e) {
+            call.reject("Failed to set video quality: " + e.getMessage());
+        }
+    }
+
+    @PluginMethod
+    public void getVideoQuality(PluginCall call) {
+        if (cameraXView == null || !cameraXView.isRunning()) {
+            call.reject("Camera is not running");
+            return;
+        }
+        JSObject ret = new JSObject();
+        ret.put("quality", cameraXView.getVideoQualitySetting());
+        call.resolve(ret);
+    }
+
+    @PluginMethod
+    public void getSupportedVideoQualities(PluginCall call) {
+        List<String> qualities = cameraXView != null
+            ? cameraXView.getSupportedVideoQualities()
+            : Arrays.asList("low", "medium", "high", "2160p", "1080p", "720p", "480p", "4:3");
+        JSONArray arr = new JSONArray();
+        for (String quality : qualities) {
+            arr.put(quality);
+        }
+        JSObject ret = new JSObject();
+        ret.put("qualities", arr);
+        call.resolve(ret);
+    }
+
+    @PluginMethod
+    public void setVideoCodec(PluginCall call) {
+        if (cameraXView == null || !cameraXView.isRunning()) {
+            call.reject("Camera is not running");
+            return;
+        }
+        String codec = call.getString("codec");
+        if (codec == null) {
+            call.reject("codec is required");
+            return;
+        }
+        try {
+            cameraXView.setVideoCodecSetting(codec);
+            call.resolve();
+        } catch (IllegalArgumentException e) {
+            call.reject(e.getMessage());
+        } catch (Exception e) {
+            call.reject("Failed to set video codec: " + e.getMessage());
+        }
+    }
+
+    @PluginMethod
+    public void getVideoCodec(PluginCall call) {
+        if (cameraXView == null || !cameraXView.isRunning()) {
+            call.reject("Camera is not running");
+            return;
+        }
+        JSObject ret = new JSObject();
+        ret.put("codec", cameraXView.getVideoCodecSetting());
+        call.resolve(ret);
+    }
+
+    @PluginMethod
+    public void getSupportedVideoCodecs(PluginCall call) {
+        List<String> codecs = cameraXView != null
+            ? cameraXView.getSupportedVideoCodecs()
+            : Arrays.asList("avc1");
+        JSONArray arr = new JSONArray();
+        for (String codec : codecs) {
+            arr.put(codec);
+        }
+        JSObject ret = new JSObject();
+        ret.put("codecs", arr);
+        call.resolve(ret);
+    }
+
+
+    @PluginMethod
     public void startRecordVideo(PluginCall call) {
         if (cameraXView == null || !cameraXView.isRunning()) {
             call.reject("Camera is not running");
@@ -2617,7 +2719,8 @@ public class CameraPreview extends Plugin implements CameraXView.CameraXViewList
 
         if (PermissionState.GRANTED.equals(getPermissionState(permissionAlias))) {
             try {
-                cameraXView.startRecordVideo();
+                applyVideoCodecFromCall(call);
+                cameraXView.startRecordVideo(getMaxDurationMillis(call), getMaxFileSize(call));
                 call.resolve();
             } catch (Exception e) {
                 call.reject("Failed to start video recording: " + e.getMessage());
@@ -2640,11 +2743,12 @@ public class CameraPreview extends Plugin implements CameraXView.CameraXViewList
             cameraXView.stopRecordVideo(
                 new CameraXView.VideoRecordingCallback() {
                     @Override
-                    public void onSuccess(String filePath) {
+                    public void onSuccess(String filePath, String reason) {
                         PluginCall saved = bridge.getSavedCall(cbId);
                         if (saved != null) {
                             JSObject result = new JSObject();
                             result.put("videoFilePath", filePath);
+                            result.put("reason", reason);
                             saved.resolve(result);
                             bridge.releaseCall(saved);
                         }
@@ -2665,6 +2769,32 @@ public class CameraPreview extends Plugin implements CameraXView.CameraXViewList
         }
     }
 
+    private void applyVideoCodecFromCall(PluginCall call) {
+        String codec = call.getString("videoCodec");
+        if (codec != null && cameraXView != null) {
+            cameraXView.setVideoCodecSetting(codec);
+        }
+    }
+
+    private Long getMaxDurationMillis(PluginCall call) {
+        if (!call.getData().has("maxDuration") || call.getData().isNull("maxDuration")) {
+            return null;
+        }
+        double seconds = call.getData().optDouble("maxDuration", 0D);
+        if (seconds <= 0D) {
+            return null;
+        }
+        return Math.max(1L, Math.round(seconds * 1000D));
+    }
+
+    private Long getMaxFileSize(PluginCall call) {
+        if (!call.getData().has("maxFileSize") || call.getData().isNull("maxFileSize")) {
+            return null;
+        }
+        long bytes = call.getData().optLong("maxFileSize", 0L);
+        return bytes > 0L ? bytes : null;
+    }
+
     @PermissionCallback
     private void handleVideoRecordingPermissionResult(PluginCall call) {
         // Use the persisted session value to determine which permission we requested
@@ -2676,7 +2806,8 @@ public class CameraPreview extends Plugin implements CameraXView.CameraXViewList
             PermissionState.GRANTED.equals(getPermissionState(CAMERA_WITH_AUDIO_PERMISSION_ALIAS))
         ) {
             try {
-                cameraXView.startRecordVideo();
+                applyVideoCodecFromCall(call);
+                cameraXView.startRecordVideo(getMaxDurationMillis(call), getMaxFileSize(call));
                 call.resolve();
             } catch (Exception e) {
                 call.reject("Failed to start video recording: " + e.getMessage());

--- a/android/src/main/java/app/capgo/capacitor/camera/preview/CameraXView.java
+++ b/android/src/main/java/app/capgo/capacitor/camera/preview/CameraXView.java
@@ -23,6 +23,8 @@ import android.hardware.camera2.CameraManager;
 import android.hardware.camera2.CaptureRequest;
 import android.location.Location;
 import android.media.Image;
+import android.media.MediaCodecList;
+import android.media.MediaFormat;
 import android.media.MediaScannerConnection;
 import android.os.Build;
 import android.os.Environment;
@@ -128,6 +130,7 @@ public class CameraXView implements LifecycleOwner, LifecycleObserver {
         void onSampleTakenError(String message);
         void onBarcodesScanned(JSONArray barcodes);
         void onBarcodeScanError(String message);
+        void onVideoRecordingFinished(String filePath, String reason);
         void onCameraStarted(int width, int height, int x, int y);
         void onCameraStartError(CameraXView source, String message);
         void onCameraStopped(CameraXView source);
@@ -139,7 +142,7 @@ public class CameraXView implements LifecycleOwner, LifecycleObserver {
     }
 
     public interface VideoRecordingCallback {
-        void onSuccess(String filePath);
+        void onSuccess(String filePath, String reason);
         void onError(String message);
     }
 
@@ -1093,24 +1096,36 @@ public class CameraXView implements LifecycleOwner, LifecycleObserver {
                     // Get quality from sessionConfig default to high if null
                     String videoQuality = sessionConfig.getVideoQuality() != null ? sessionConfig.getVideoQuality() : "high";
 
-                    switch (videoQuality.toLowerCase()) {
-                        case "low":
-                            // Target SD, allow falling back to lower if needed
+                    switch (videoQuality.toLowerCase(Locale.US)) {
+                        case "2160p":
                             qualitySelector = QualitySelector.fromOrderedList(
-                                Arrays.asList(Quality.SD, Quality.LOWEST),
-                                FallbackStrategy.lowerQualityOrHigherThan(Quality.SD)
+                                Arrays.asList(Quality.UHD, Quality.FHD, Quality.HD, Quality.SD),
+                                FallbackStrategy.lowerQualityOrHigherThan(Quality.UHD)
                             );
                             break;
+                        case "1080p":
+                            qualitySelector = QualitySelector.fromOrderedList(
+                                Arrays.asList(Quality.FHD, Quality.HD, Quality.SD),
+                                FallbackStrategy.higherQualityOrLowerThan(Quality.FHD)
+                            );
+                            break;
+                        case "720p":
                         case "medium":
-                            // Target HD, allow falling back to SD
                             qualitySelector = QualitySelector.fromOrderedList(
                                 Arrays.asList(Quality.HD, Quality.SD),
                                 FallbackStrategy.lowerQualityOrHigherThan(Quality.HD)
                             );
                             break;
+                        case "480p":
+                        case "low":
+                            qualitySelector = QualitySelector.fromOrderedList(
+                                Arrays.asList(Quality.SD, Quality.LOWEST),
+                                FallbackStrategy.lowerQualityOrHigherThan(Quality.SD)
+                            );
+                            break;
                         case "high":
+                        case "4:3":
                         default:
-                            // Target FHD allow falling back SD
                             qualitySelector = QualitySelector.fromOrderedList(
                                 Arrays.asList(Quality.FHD, Quality.HD, Quality.SD),
                                 FallbackStrategy.higherQualityOrLowerThan(Quality.FHD)
@@ -1118,7 +1133,12 @@ public class CameraXView implements LifecycleOwner, LifecycleObserver {
                             break;
                     }
 
-                    Recorder recorder = new Recorder.Builder().setQualitySelector(qualitySelector).build();
+                    Recorder.Builder recorderBuilder = new Recorder.Builder().setQualitySelector(qualitySelector);
+                    String videoCodec = sessionConfig.getVideoCodec() != null ? sessionConfig.getVideoCodec() : "avc1";
+                    if ("hvc1".equalsIgnoreCase(videoCodec)) {
+                        recorderBuilder.setVideoCapabilitiesSource(Recorder.VIDEO_CAPABILITIES_SOURCE_CODEC_CAPABILITIES);
+                    }
+                    Recorder recorder = recorderBuilder.build();
                     videoCapture = VideoCapture.withOutput(recorder);
                 }
 
@@ -4644,7 +4664,7 @@ public class CameraXView implements LifecycleOwner, LifecycleObserver {
     }
 
     /** @noinspection ResultOfMethodCallIgnored*/
-    public void startRecordVideo() throws Exception {
+    public void startRecordVideo(Long maxDurationMillis, Long maxFileSize) throws Exception {
         if (videoCapture == null) {
             throw new Exception("VideoCapture is not initialized");
         }
@@ -4666,7 +4686,14 @@ public class CameraXView implements LifecycleOwner, LifecycleObserver {
         }
         currentVideoFile = new File(outputDir, fileName);
 
-        FileOutputOptions outputOptions = new FileOutputOptions.Builder(currentVideoFile).build();
+        FileOutputOptions.Builder outputOptionsBuilder = new FileOutputOptions.Builder(currentVideoFile);
+        if (maxDurationMillis != null && maxDurationMillis > 0) {
+            outputOptionsBuilder.setDurationLimitMillis(maxDurationMillis);
+        }
+        if (maxFileSize != null && maxFileSize > 0) {
+            outputOptionsBuilder.setFileSizeLimit(maxFileSize);
+        }
+        FileOutputOptions outputOptions = outputOptionsBuilder.build();
 
         // Create recording event listener
         androidx.core.util.Consumer<VideoRecordEvent> videoRecordEventListener = (videoRecordEvent) -> {
@@ -4712,11 +4739,18 @@ public class CameraXView implements LifecycleOwner, LifecycleObserver {
     }
 
     private void handleRecordingFinalized(VideoRecordEvent.Finalize finalizeEvent) {
-        if (!finalizeEvent.hasError()) {
-            Log.d(TAG, "Video recording completed successfully");
+        String reason = getRecordingFinishReason(finalizeEvent.getError());
+        boolean hasVideoFile = currentVideoFile != null && currentVideoFile.exists();
+        boolean finishedWithUsableFile = !finalizeEvent.hasError() || isRecordingLimitReached(finalizeEvent.getError());
+
+        if (finishedWithUsableFile && hasVideoFile) {
+            String filePath = "file://" + currentVideoFile.getAbsolutePath();
+            Log.d(TAG, "Video recording completed: " + reason);
             if (currentVideoCallback != null) {
-                String filePath = "file://" + currentVideoFile.getAbsolutePath();
-                currentVideoCallback.onSuccess(filePath);
+                currentVideoCallback.onSuccess(filePath, reason);
+            }
+            if (listener != null) {
+                listener.onVideoRecordingFinished(filePath, reason);
             }
         } else {
             Log.e(TAG, "Video recording failed: " + finalizeEvent.getError());
@@ -4730,4 +4764,114 @@ public class CameraXView implements LifecycleOwner, LifecycleObserver {
         currentVideoFile = null;
         currentVideoCallback = null;
     }
+
+    private boolean isRecordingLimitReached(int error) {
+        return (
+            error == VideoRecordEvent.Finalize.ERROR_DURATION_LIMIT_REACHED ||
+            error == VideoRecordEvent.Finalize.ERROR_FILE_SIZE_LIMIT_REACHED
+        );
+    }
+
+    private String getRecordingFinishReason(int error) {
+        if (error == VideoRecordEvent.Finalize.ERROR_DURATION_LIMIT_REACHED) {
+            return "maxDuration";
+        }
+        if (error == VideoRecordEvent.Finalize.ERROR_FILE_SIZE_LIMIT_REACHED) {
+            return "maxFileSize";
+        }
+        return "manual";
+    }
+
+    private static final List<String> ALL_VIDEO_QUALITIES = Arrays.asList(
+        "low",
+        "medium",
+        "high",
+        "2160p",
+        "1080p",
+        "720p",
+        "480p",
+        "4:3"
+    );
+
+    private static final List<String> ALL_VIDEO_CODECS = Arrays.asList("avc1", "hvc1");
+
+    public String getVideoQualitySetting() {
+        if (sessionConfig == null) {
+            return "high";
+        }
+        return sessionConfig.getVideoQuality();
+    }
+
+    public void setVideoQualitySetting(String quality) {
+        if (sessionConfig == null) {
+            throw new IllegalStateException("Camera session is not running");
+        }
+        String normalized = quality != null ? quality.toLowerCase(Locale.US) : "high";
+        if (!ALL_VIDEO_QUALITIES.contains(normalized)) {
+            throw new IllegalArgumentException("Unsupported video quality: " + quality);
+        }
+        if (normalized.equals(sessionConfig.getVideoQuality())) {
+            return;
+        }
+        sessionConfig.setVideoQuality(normalized);
+        if (sessionConfig.isVideoModeEnabled() && isRunning) {
+            mainExecutor.execute(this::bindCameraUseCases);
+        }
+    }
+
+    public List<String> getSupportedVideoQualities() {
+        return new ArrayList<>(ALL_VIDEO_QUALITIES);
+    }
+
+    public String getVideoCodecSetting() {
+        if (sessionConfig == null) {
+            return "avc1";
+        }
+        return sessionConfig.getVideoCodec();
+    }
+
+    public void setVideoCodecSetting(String codec) {
+        if (sessionConfig == null) {
+            throw new IllegalStateException("Camera session is not running");
+        }
+        String normalized = codec != null ? codec.toLowerCase(Locale.US) : "avc1";
+        if (!ALL_VIDEO_CODECS.contains(normalized)) {
+            throw new IllegalArgumentException("Unsupported video codec: " + codec);
+        }
+        if (normalized.equals(sessionConfig.getVideoCodec())) {
+            return;
+        }
+        sessionConfig.setVideoCodec(normalized);
+        if (sessionConfig.isVideoModeEnabled() && isRunning) {
+            mainExecutor.execute(this::bindCameraUseCases);
+        }
+    }
+
+    public List<String> getSupportedVideoCodecs() {
+        List<String> codecs = new ArrayList<>();
+        codecs.add("avc1");
+        if (isVideoCodecSupported(MediaFormat.MIMETYPE_VIDEO_HEVC)) {
+            codecs.add("hvc1");
+        }
+        return codecs;
+    }
+
+    private boolean isVideoCodecSupported(String mimeType) {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {
+            return false;
+        }
+        MediaCodecList codecList = new MediaCodecList(MediaCodecList.REGULAR_CODECS);
+        for (android.media.MediaCodecInfo codecInfo : codecList.getCodecInfos()) {
+            if (!codecInfo.isEncoder()) {
+                continue;
+            }
+            for (String type : codecInfo.getSupportedTypes()) {
+                if (mimeType.equalsIgnoreCase(type)) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
 }

--- a/android/src/main/java/app/capgo/capacitor/camera/preview/CameraXView.java
+++ b/android/src/main/java/app/capgo/capacitor/camera/preview/CameraXView.java
@@ -4782,16 +4782,7 @@ public class CameraXView implements LifecycleOwner, LifecycleObserver {
         return "manual";
     }
 
-    private static final List<String> ALL_VIDEO_QUALITIES = Arrays.asList(
-        "low",
-        "medium",
-        "high",
-        "2160p",
-        "1080p",
-        "720p",
-        "480p",
-        "4:3"
-    );
+    private static final List<String> ALL_VIDEO_QUALITIES = Arrays.asList("low", "medium", "high", "2160p", "1080p", "720p", "480p", "4:3");
 
     private static final List<String> ALL_VIDEO_CODECS = Arrays.asList("avc1", "hvc1");
 
@@ -4873,5 +4864,4 @@ public class CameraXView implements LifecycleOwner, LifecycleObserver {
         }
         return false;
     }
-
 }

--- a/android/src/main/java/app/capgo/capacitor/camera/preview/model/CameraSessionConfiguration.java
+++ b/android/src/main/java/app/capgo/capacitor/camera/preview/model/CameraSessionConfiguration.java
@@ -25,7 +25,8 @@ public class CameraSessionConfiguration {
     private final boolean enableVideoMode;
     private float targetZoom = 1.0f;
     private boolean isCentered = false;
-    private final String videoQuality;
+    private String videoQuality;
+    private String videoCodec = "avc1";
     private boolean enablePhysicalDeviceSelection = false;
     private boolean barcodeScannerEnabled = false;
 
@@ -145,6 +146,18 @@ public class CameraSessionConfiguration {
 
     public String getVideoQuality() {
         return videoQuality;
+    }
+
+    public void setVideoQuality(String quality) {
+        this.videoQuality = quality != null ? quality : "high";
+    }
+
+    public String getVideoCodec() {
+        return videoCodec;
+    }
+
+    public void setVideoCodec(String codec) {
+        this.videoCodec = codec != null ? codec : "avc1";
     }
 
     public boolean isPhysicalDeviceSelectionEnabled() {

--- a/ios/Sources/CapgoCameraPreviewPlugin/CameraController.swift
+++ b/ios/Sources/CapgoCameraPreviewPlugin/CameraController.swift
@@ -214,8 +214,6 @@ class CameraController: NSObject {
         }
     }
 
-
-
     // Track output preparation status
     private var outputsPrepared: Bool = false
 
@@ -2475,7 +2473,6 @@ extension CameraController {
             throw CameraControllerError.invalidOperation
         }
     }
-
 
     func captureVideo(maxDuration: Float? = nil, maxFileSize: Int? = nil) throws {
         guard let captureSession = self.captureSession, captureSession.isRunning else {

--- a/ios/Sources/CapgoCameraPreviewPlugin/CameraController.swift
+++ b/ios/Sources/CapgoCameraPreviewPlugin/CameraController.swift
@@ -140,9 +140,81 @@ class CameraController: NSObject {
     private var lastCaptureOrientation: AVCaptureVideoOrientation?
 
     var videoFileURL: URL?
+    var recordingFinishedCallback: ((URL, String) -> Void)?
     private let saneMaxZoomFactor: CGFloat = 25.5
 
     var videoQuality: String = "high"
+    var videoCodec: String = "avc1"
+
+    private static let allVideoQualities = ["low", "medium", "high", "2160p", "1080p", "720p", "480p", "4:3"]
+
+    func getSupportedVideoQualities() -> [String] {
+        guard let captureSession = self.captureSession else {
+            return Self.allVideoQualities
+        }
+        let device = self.currentCameraPosition == .front ? self.frontCamera : self.rearCamera
+        guard let device = device else {
+            return Self.allVideoQualities
+        }
+        return Self.allVideoQualities.filter { quality in
+            let preset = self.bestPreset(for: self.requestedAspectRatio, quality: quality, on: device)
+            return captureSession.canSetSessionPreset(preset)
+        }
+    }
+
+    func setVideoQuality(_ quality: String) throws {
+        guard Self.allVideoQualities.contains(quality.lowercased()) else {
+            throw CameraControllerError.invalidOperation
+        }
+        self.videoQuality = quality.lowercased()
+        self.configureSessionPreset(for: self.requestedAspectRatio)
+    }
+
+    func getVideoQuality() -> String {
+        return self.videoQuality
+    }
+
+    func getSupportedVideoCodecs() -> [String] {
+        guard let fileVideoOutput = self.fileVideoOutput else {
+            return ["avc1"]
+        }
+        var codecs: [String] = []
+        if fileVideoOutput.availableVideoCodecTypes.contains(.h264) {
+            codecs.append("avc1")
+        }
+        if fileVideoOutput.availableVideoCodecTypes.contains(.hevc) {
+            codecs.append("hvc1")
+        }
+        return codecs.isEmpty ? ["avc1"] : codecs
+    }
+
+    func setVideoCodec(_ codec: String) throws {
+        let normalized = codec.lowercased()
+        guard ["avc1", "hvc1"].contains(normalized) else {
+            throw CameraControllerError.invalidOperation
+        }
+        if !getSupportedVideoCodecs().contains(normalized) {
+            throw CameraControllerError.invalidOperation
+        }
+        self.videoCodec = normalized
+    }
+
+    func getVideoCodec() -> String {
+        return self.videoCodec
+    }
+
+    private func avVideoCodecType(for codec: String) -> AVVideoCodecType? {
+        switch codec.lowercased() {
+        case "avc1":
+            return .h264
+        case "hvc1":
+            return .hevc
+        default:
+            return nil
+        }
+    }
+
+
 
     // Track output preparation status
     private var outputsPrepared: Bool = false
@@ -528,28 +600,40 @@ extension CameraController {
 
         // Prioritize video quality setting
         switch self.videoQuality.lowercased() {
-        case "low":
-            // Match Android "Low" (SD/480p)
-            if captureSession.canSetSessionPreset(.vga640x480) {
-                targetPreset = .vga640x480
-            } else {
-                targetPreset = .low
+        case "2160p":
+            if captureSession.canSetSessionPreset(.hd4K3840x2160) {
+                targetPreset = .hd4K3840x2160
+            } else if captureSession.canSetSessionPreset(.hd1920x1080) {
+                targetPreset = .hd1920x1080
             }
-        case "medium":
-            // Match Android "Medium" (HD/720p)
+        case "1080p":
+            if captureSession.canSetSessionPreset(.hd1920x1080) {
+                targetPreset = .hd1920x1080
+            } else if captureSession.canSetSessionPreset(.hd1280x720) {
+                targetPreset = .hd1280x720
+            }
+        case "720p", "medium":
             if captureSession.canSetSessionPreset(.hd1280x720) {
                 targetPreset = .hd1280x720
             } else {
                 targetPreset = .medium
             }
+        case "480p", "low":
+            if captureSession.canSetSessionPreset(.vga640x480) {
+                targetPreset = .vga640x480
+            } else {
+                targetPreset = .low
+            }
+        case "4:3":
+            if captureSession.canSetSessionPreset(.photo) {
+                targetPreset = .photo
+            } else if captureSession.canSetSessionPreset(.high) {
+                targetPreset = .high
+            }
         case "high":
-            // Exisiting logic for High Quality (4K/1080p based on Asepct Ratio)
-
             if let aspectRatio = aspectRatio {
                 switch aspectRatio {
                 case "16:9":
-                    // Start with 1080p for faster initialization, 4K only when explicitly needed
-                    // This maintains capture quality while optimizing preview performance
                     if captureSession.canSetSessionPreset(.hd1920x1080) {
                         targetPreset = .hd1920x1080
                     } else if captureSession.canSetSessionPreset(.hd4K3840x2160) {
@@ -573,7 +657,6 @@ extension CameraController {
                     }
                 }
             }
-        // Handle unexpected values
         default:
             if captureSession.canSetSessionPreset(.photo) {
                 targetPreset = .photo
@@ -893,28 +976,37 @@ extension CameraController {
 
         // Handle specific quality overrides first
         switch quality.lowercased() {
-        case "low":
-            if device.supportsSessionPreset(.vga640x480) { return .vga640x480 }
-            return .low
-        case "medium":
+        case "2160p":
+            if device.supportsSessionPreset(.hd4K3840x2160) { return .hd4K3840x2160 }
+            if device.supportsSessionPreset(.hd1920x1080) { return .hd1920x1080 }
+            if device.supportsSessionPreset(.hd1280x720) { return .hd1280x720 }
+            return .vga640x480
+        case "1080p":
+            if device.supportsSessionPreset(.hd1920x1080) { return .hd1920x1080 }
+            if device.supportsSessionPreset(.hd1280x720) { return .hd1280x720 }
+            return .vga640x480
+        case "720p", "medium":
             if device.supportsSessionPreset(.hd1280x720) { return .hd1280x720 }
             return .medium
-        case "high":
-            break // Exit and go off code below
+        case "480p", "low":
+            if device.supportsSessionPreset(.vga640x480) { return .vga640x480 }
+            return .low
+        case "4:3":
+            if device.supportsSessionPreset(.photo) { return .photo }
+            if device.supportsSessionPreset(.high) { return .high }
+            return .vga640x480
         default:
-            break // Exit and go off code below
+            break
         }
         // Preference order depends on aspect ratio
         if aspectRatio == "16:9" {
-            // Prefer 4K → 1080p → 720p → high → photo → vga
             if device.supportsSessionPreset(.hd4K3840x2160) { return .hd4K3840x2160 }
             if device.supportsSessionPreset(.hd1920x1080) { return .hd1920x1080 }
             if device.supportsSessionPreset(.hd1280x720) { return .hd1280x720 }
             if device.supportsSessionPreset(.high) { return .high }
-            if device.supportsSessionPreset(.photo) { return .photo } // safe, though 4:3
+            if device.supportsSessionPreset(.photo) { return .photo }
             return .vga640x480
         } else {
-            // 4:3 or unknown: prefer photo → high → 1080p → 720p → vga
             if device.supportsSessionPreset(.photo) { return .photo }
             if device.supportsSessionPreset(.high) { return .high }
             if device.supportsSessionPreset(.hd1920x1080) { return .hd1920x1080 }
@@ -2384,7 +2476,8 @@ extension CameraController {
         }
     }
 
-    func captureVideo() throws {
+
+    func captureVideo(maxDuration: Float? = nil, maxFileSize: Int? = nil) throws {
         guard let captureSession = self.captureSession, captureSession.isRunning else {
             throw CameraControllerError.captureSessionIsMissing
         }
@@ -2443,6 +2536,19 @@ extension CameraController {
 
         let fileUrl = documentsDirectory.appendingPathComponent(fileName)
         try? FileManager.default.removeItem(at: fileUrl)
+
+        if let maxDuration = maxDuration, maxDuration > 0 {
+            fileVideoOutput.maxRecordedDuration = CMTime(seconds: Double(maxDuration), preferredTimescale: 600)
+        } else {
+            fileVideoOutput.maxRecordedDuration = .invalid
+        }
+        fileVideoOutput.maxRecordedFileSize = Int64(maxFileSize ?? 0)
+
+        if let connection = fileVideoOutput.connection(with: .video),
+           let codecType = avVideoCodecType(for: self.videoCodec),
+           fileVideoOutput.availableVideoCodecTypes.contains(codecType) {
+            fileVideoOutput.setOutputSettings([AVVideoCodecKey: codecType], for: connection)
+        }
 
         // Start recording video
         fileVideoOutput.startRecording(to: fileUrl, recordingDelegate: self)
@@ -2857,11 +2963,33 @@ extension UIImage {
 
 extension CameraController: AVCaptureFileOutputRecordingDelegate {
     func fileOutput(_ output: AVCaptureFileOutput, didFinishRecordingTo outputFileURL: URL, from connections: [AVCaptureConnection], error: Error?) {
-        if let error = error {
-            print("Error recording movie: \(error.localizedDescription)")
-        } else {
-            print("Movie recorded successfully: \(outputFileURL)")
-            // You can save the file to the library, upload it, etc.
+        let reason = recordingFinishReason(from: error)
+        if reason == "error" {
+            print("Error recording movie: \(error?.localizedDescription ?? "unknown")")
+            return
+        }
+
+        print("Movie recorded successfully: \(outputFileURL)")
+        self.recordingFinishedCallback?(outputFileURL, reason)
+    }
+
+    private func recordingFinishReason(from error: Error?) -> String {
+        guard let error = error else {
+            return "manual"
+        }
+
+        let nsError = error as NSError
+        guard nsError.domain == AVFoundationErrorDomain else {
+            return "error"
+        }
+
+        switch AVError.Code(rawValue: nsError.code) {
+        case .maximumDurationReached:
+            return "maxDuration"
+        case .maximumFileSizeReached:
+            return "maxFileSize"
+        default:
+            return "error"
         }
     }
 }

--- a/ios/Sources/CapgoCameraPreviewPlugin/Plugin.swift
+++ b/ios/Sources/CapgoCameraPreviewPlugin/Plugin.swift
@@ -51,6 +51,12 @@ public class CameraPreview: CAPPlugin, CAPBridgedPlugin, CLLocationManagerDelega
         CAPPluginMethod(name: "setFlashMode", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "startRecordVideo", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "stopRecordVideo", returnType: CAPPluginReturnPromise),
+        CAPPluginMethod(name: "getSupportedVideoCodecs", returnType: CAPPluginReturnPromise),
+        CAPPluginMethod(name: "getVideoCodec", returnType: CAPPluginReturnPromise),
+        CAPPluginMethod(name: "setVideoCodec", returnType: CAPPluginReturnPromise),
+        CAPPluginMethod(name: "getSupportedVideoQualities", returnType: CAPPluginReturnPromise),
+        CAPPluginMethod(name: "getVideoQuality", returnType: CAPPluginReturnPromise),
+        CAPPluginMethod(name: "setVideoQuality", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "getTempFilePath", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "getSupportedPictureSizes", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "isRunning", returnType: CAPPluginReturnPromise),
@@ -1595,9 +1601,64 @@ public class CameraPreview: CAPPlugin, CAPBridgedPlugin, CLLocationManagerDelega
         }
     }
 
-    @objc func startRecordVideo(_ call: CAPPluginCall) {
+
+    @objc func setVideoQuality(_ call: CAPPluginCall) {
+        guard let quality = call.getString("quality") else {
+            call.reject("quality is required")
+            return
+        }
         do {
-            try self.cameraController.captureVideo()
+            try self.cameraController.setVideoQuality(quality)
+            call.resolve()
+        } catch {
+            call.reject("Failed to set video quality: \(error.localizedDescription)")
+        }
+    }
+
+    @objc func getVideoQuality(_ call: CAPPluginCall) {
+        call.resolve(["quality": self.cameraController.getVideoQuality()])
+    }
+
+    @objc func getSupportedVideoQualities(_ call: CAPPluginCall) {
+        call.resolve(["qualities": self.cameraController.getSupportedVideoQualities()])
+    }
+
+    @objc func setVideoCodec(_ call: CAPPluginCall) {
+        guard let codec = call.getString("codec") else {
+            call.reject("codec is required")
+            return
+        }
+        do {
+            try self.cameraController.setVideoCodec(codec)
+            call.resolve()
+        } catch {
+            call.reject("Failed to set video codec: \(error.localizedDescription)")
+        }
+    }
+
+    @objc func getVideoCodec(_ call: CAPPluginCall) {
+        call.resolve(["codec": self.cameraController.getVideoCodec()])
+    }
+
+    @objc func getSupportedVideoCodecs(_ call: CAPPluginCall) {
+        call.resolve(["codecs": self.cameraController.getSupportedVideoCodecs()])
+    }
+
+
+    @objc func startRecordVideo(_ call: CAPPluginCall) {
+        let maxDuration = call.getFloat("maxDuration")
+        let maxFileSize = call.getInt("maxFileSize")
+        if let videoCodec = call.getString("videoCodec") {
+            try? self.cameraController.setVideoCodec(videoCodec)
+        }
+        self.cameraController.recordingFinishedCallback = { [weak self] fileURL, reason in
+            DispatchQueue.main.async {
+                self?.notifyListeners("recordingFinished", data: ["videoFilePath": fileURL.absoluteString, "reason": reason])
+            }
+        }
+
+        do {
+            try self.cameraController.captureVideo(maxDuration: maxDuration, maxFileSize: maxFileSize)
             call.resolve()
         } catch {
             call.reject(error.localizedDescription)
@@ -1616,7 +1677,7 @@ public class CameraPreview: CAPPlugin, CAPBridgedPlugin, CLLocationManagerDelega
                 return
             }
 
-            call.resolve(["videoFilePath": fileURL.absoluteString])
+            call.resolve(["videoFilePath": fileURL.absoluteString, "reason": "manual"])
         }
     }
 

--- a/ios/Sources/CapgoCameraPreviewPlugin/Plugin.swift
+++ b/ios/Sources/CapgoCameraPreviewPlugin/Plugin.swift
@@ -1601,7 +1601,6 @@ public class CameraPreview: CAPPlugin, CAPBridgedPlugin, CLLocationManagerDelega
         }
     }
 
-
     @objc func setVideoQuality(_ call: CAPPluginCall) {
         guard let quality = call.getString("quality") else {
             call.reject("quality is required")
@@ -1643,7 +1642,6 @@ public class CameraPreview: CAPPlugin, CAPBridgedPlugin, CLLocationManagerDelega
     @objc func getSupportedVideoCodecs(_ call: CAPPluginCall) {
         call.resolve(["codecs": self.cameraController.getSupportedVideoCodecs()])
     }
-
 
     @objc func startRecordVideo(_ call: CAPPluginCall) {
         let maxDuration = call.getFloat("maxDuration")

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -768,7 +768,6 @@ export interface CameraPreviewPlugin {
    */
   getSupportedVideoCodecs(): Promise<{ codecs: VideoCodec[] }>;
 
-
   /**
    * Checks if the camera preview is currently running.
    *

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -138,6 +138,28 @@ export interface LensInfo {
   digitalZoom: number;
 }
 
+export type VideoQuality = 'low' | 'medium' | 'high' | '2160p' | '1080p' | '720p' | '480p' | '4:3';
+
+/**
+ * Video codec identifiers used when recording.
+ * - `avc1`: H.264
+ * - `hvc1`: HEVC / H.265
+ */
+export type VideoCodec = 'avc1' | 'hvc1' | 'jpeg' | 'apcn' | 'ap4h';
+
+export type RecordingFinishedReason = 'manual' | 'maxDuration' | 'maxFileSize';
+
+export interface RecordingFinishedEvent {
+  /**
+   * The path to the recorded video file.
+   */
+  videoFilePath: string;
+  /**
+   * Why the recording stopped.
+   */
+  reason: RecordingFinishedReason;
+}
+
 /**
  * Defines the configuration options for starting the camera preview.
  */
@@ -301,13 +323,29 @@ export interface CameraPreviewOptions {
   force?: boolean;
   /**
    * Sets the quality of video for recording.
-   * Options: 'low', 'medium', 'high'
+   * Options: 'low', 'medium', 'high', '2160p', '1080p', '720p', '480p', '4:3'
    * @note On Android requires 'enableVideoMode' to be true
    * @note Will affect the entire preview stream for iOS
    * @platform ios, android
    * @default "high"
    */
-  videoQuality?: 'low' | 'medium' | 'high';
+  videoQuality?: VideoQuality;
+  /**
+   * Maximum recording duration in seconds. Recording stops automatically when reached.
+   * @platform ios, android
+   */
+  maxDuration?: number;
+  /**
+   * Maximum recording file size in bytes. Recording stops automatically when reached.
+   * @platform ios, android
+   */
+  maxFileSize?: number;
+  /**
+   * Preferred video codec for recording.
+   * @platform ios, android
+   * @default "avc1"
+   */
+  videoCodec?: VideoCodec;
   /**
    * Starts barcode scanning together with the camera preview.
    * Set to `true` or pass options to scan all supported formats.
@@ -660,19 +698,76 @@ export interface CameraPreviewPlugin {
   /**
    * Stops an ongoing video recording.
    *
-   * @returns {Promise<{ videoFilePath: string }>} A promise that resolves with the path to the recorded video file.
+   * @returns {Promise<RecordingFinishedEvent>} A promise that resolves with the path to the recorded video file.
    * @since 0.0.1
    */
-  stopRecordVideo(): Promise<{ videoFilePath: string }>;
+  stopRecordVideo(): Promise<RecordingFinishedEvent>;
 
   /**
    * Starts recording a video.
    *
-   * @param {CameraPreviewOptions} options - The options for video recording. Only iOS.
+   * @param {CameraPreviewOptions} options - The options for video recording.
    * @returns {Promise<void>} A promise that resolves when video recording starts.
    * @since 0.0.1
    */
   startRecordVideo(options: CameraPreviewOptions): Promise<void>;
+
+  /**
+   * Sets the video recording quality for the active camera session.
+   *
+   * @param {{ quality: VideoQuality }} options - The desired video quality.
+   * @returns {Promise<void>} A promise that resolves when the quality is set.
+   * @since 8.5.0
+   * @platform android, ios
+   */
+  setVideoQuality(options: { quality: VideoQuality }): Promise<void>;
+
+  /**
+   * Gets the current video recording quality.
+   *
+   * @returns {Promise<{ quality: VideoQuality }>} A promise that resolves with the current quality.
+   * @since 8.5.0
+   * @platform android, ios
+   */
+  getVideoQuality(): Promise<{ quality: VideoQuality }>;
+
+  /**
+   * Returns the video qualities supported by the active camera.
+   *
+   * @returns {Promise<{ qualities: VideoQuality[] }>} A promise that resolves with supported qualities.
+   * @since 8.5.0
+   * @platform android, ios
+   */
+  getSupportedVideoQualities(): Promise<{ qualities: VideoQuality[] }>;
+
+  /**
+   * Sets the video codec used when recording.
+   *
+   * @param {{ codec: VideoCodec }} options - The desired codec.
+   * @returns {Promise<void>} A promise that resolves when the codec is set.
+   * @since 8.5.0
+   * @platform android, ios
+   */
+  setVideoCodec(options: { codec: VideoCodec }): Promise<void>;
+
+  /**
+   * Gets the current video codec used for recording.
+   *
+   * @returns {Promise<{ codec: VideoCodec }>} A promise that resolves with the current codec.
+   * @since 8.5.0
+   * @platform android, ios
+   */
+  getVideoCodec(): Promise<{ codec: VideoCodec }>;
+
+  /**
+   * Returns the video codecs supported by the active camera.
+   *
+   * @returns {Promise<{ codecs: VideoCodec[] }>} A promise that resolves with supported codecs.
+   * @since 8.5.0
+   * @platform android, ios
+   */
+  getSupportedVideoCodecs(): Promise<{ codecs: VideoCodec[] }>;
+
 
   /**
    * Checks if the camera preview is currently running.
@@ -849,6 +944,17 @@ export interface CameraPreviewPlugin {
   addListener(
     eventName: 'barcodeScanError',
     listenerFunc: (data: BarcodeScanErrorEvent) => void,
+  ): Promise<PluginListenerHandle>;
+
+  /**
+   * Adds a listener fired when a video recording finishes natively, including automatic stops.
+   *
+   * @since 8.4.7
+   * @platform android, ios
+   */
+  addListener(
+    eventName: 'recordingFinished',
+    listenerFunc: (data: RecordingFinishedEvent) => void,
   ): Promise<PluginListenerHandle>;
   /**
    * Deletes a file at the given absolute path on the device.

--- a/src/web.ts
+++ b/src/web.ts
@@ -967,7 +967,6 @@ export class CameraPreviewWeb extends WebPlugin implements CameraPreviewPlugin {
     if (!!video && !!_options.opacity) video.style.setProperty('opacity', _options.opacity.toString());
   }
 
-
   async setVideoQuality(): Promise<void> {
     throw this.unimplemented('setVideoQuality');
   }

--- a/src/web.ts
+++ b/src/web.ts
@@ -22,6 +22,8 @@ import type {
   LensInfo,
   PermissionRequestOptions,
   SafeAreaInsets,
+  VideoCodec,
+  VideoQuality,
 } from './definitions';
 import { DeviceType } from './definitions';
 
@@ -847,7 +849,7 @@ export class CameraPreviewWeb extends WebPlugin implements CameraPreviewPlugin {
           this.mediaRecorder = null;
 
           const videoFilePath = URL.createObjectURL(blob);
-          resolve({ videoFilePath });
+          resolve({ videoFilePath, reason: 'manual' });
         } catch (error) {
           reject(error);
         }
@@ -963,6 +965,31 @@ export class CameraPreviewWeb extends WebPlugin implements CameraPreviewPlugin {
   async setOpacity(_options: CameraOpacityOptions): Promise<any> {
     const video = document.getElementById(DEFAULT_VIDEO_ID) as HTMLVideoElement;
     if (!!video && !!_options.opacity) video.style.setProperty('opacity', _options.opacity.toString());
+  }
+
+
+  async setVideoQuality(): Promise<void> {
+    throw this.unimplemented('setVideoQuality');
+  }
+
+  async getVideoQuality(): Promise<{ quality: VideoQuality }> {
+    throw this.unimplemented('getVideoQuality');
+  }
+
+  async getSupportedVideoQualities(): Promise<{ qualities: VideoQuality[] }> {
+    throw this.unimplemented('getSupportedVideoQualities');
+  }
+
+  async setVideoCodec(): Promise<void> {
+    throw this.unimplemented('setVideoCodec');
+  }
+
+  async getVideoCodec(): Promise<{ codec: VideoCodec }> {
+    throw this.unimplemented('getVideoCodec');
+  }
+
+  async getSupportedVideoCodecs(): Promise<{ codecs: VideoCodec[] }> {
+    throw this.unimplemented('getSupportedVideoCodecs');
   }
 
   async isRunning(): Promise<{ isRunning: boolean }> {


### PR DESCRIPTION
## Summary

- Adds explicit `videoQuality` presets (`2160p`, `1080p`, `720p`, `480p`, `4:3`) alongside existing `low`/`medium`/`high` values on iOS and Android
- Adds `setVideoQuality` / `getVideoQuality` / `getSupportedVideoQualities` and `setVideoCodec` / `getVideoCodec` / `getSupportedVideoCodecs` APIs for runtime recording settings
- Adds `maxDuration` and `maxFileSize` options to `startRecordVideo`, returns a `reason` from `stopRecordVideo`, and emits a `recordingFinished` listener when recording stops (manual or limit reached)

## Test plan

- [x] `bun run verify` (iOS Swift build, Android Gradle, web TypeScript/rollup)
- [ ] Start preview with `videoQuality: '1080p'` and confirm preview/recording resolution on device
- [ ] Call `setVideoQuality({ quality: '720p' })` while preview is running and verify rebind
- [ ] Record with `maxDuration: 5` and confirm auto-stop + `recordingFinished` event with `reason: 'maxDuration'`
- [ ] Record with `maxFileSize` limit and confirm auto-stop with `reason: 'maxFileSize'`
- [ ] Set codec to `avc1` / `hvc1` on iOS and verify supported codecs list

Closes #366

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **New Features**
  * Configure video recording quality (including higher-resolution options) and codec selection
  * Set maximum recording duration and file size limits
  * Recording completion event now reports why recording stopped (manual stop, duration limit reached, or file size limit reached)
  * Query available video qualities and supported codecs for your device

<!-- end of auto-generated comment: release notes by coderabbit.ai -->