### PR TITLE
feat: video frame-rate controls (closes #371)

### DIFF
--- a/README.md
+++ b/README.md
@@ -408,6 +408,9 @@ Documentation for the [uploader](https://github.com/Cap-go/capacitor-uploader)
 * [`getExposureCompensationRange()`](#getexposurecompensationrange)
 * [`getExposureCompensation()`](#getexposurecompensation)
 * [`setExposureCompensation(...)`](#setexposurecompensation)
+* [`getSupportedVideoFrameRates()`](#getsupportedvideoframerates)
+* [`getVideoFrameRate()`](#getvideoframerate)
+* [`setVideoFrameRate(...)`](#setvideoframerate)
 * [`getPluginVersion()`](#getpluginversion)
 * [Interfaces](#interfaces)
 * [Type Aliases](#type-aliases)
@@ -1287,6 +1290,56 @@ Sets the exposure compensation (EV bias). Value will be clamped to range.
 | Param         | Type                            |
 | ------------- | ------------------------------- |
 | **`options`** | <code>{ value: number; }</code> |
+
+--------------------
+
+
+### getSupportedVideoFrameRates()
+
+```typescript
+getSupportedVideoFrameRates() => Promise<{ frameRates: number[]; }>
+```
+
+Lists the video frame rates supported by the active camera for the current format.
+Supported values depend on the selected camera, lens, and video quality.
+
+**Returns:** <code>Promise&lt;{ frameRates: number[]; }&gt;</code>
+
+**Since:** 8.6.0
+
+--------------------
+
+
+### getVideoFrameRate()
+
+```typescript
+getVideoFrameRate() => Promise<{ frameRate: number; }>
+```
+
+Returns the configured video frame rate for the active camera.
+On Android the actual recording frame rate can still vary in low light or under thermal pressure.
+
+**Returns:** <code>Promise&lt;{ frameRate: number; }&gt;</code>
+
+**Since:** 8.6.0
+
+--------------------
+
+
+### setVideoFrameRate(...)
+
+```typescript
+setVideoFrameRate(options: { frameRate: number; }) => Promise<void>
+```
+
+Sets the target video frame rate before recording starts.
+Rejects unsupported values with a clear error.
+
+| Param         | Type                                |
+| ------------- | ----------------------------------- |
+| **`options`** | <code>{ frameRate: number; }</code> |
+
+**Since:** 8.6.0
 
 --------------------
 

--- a/README.md
+++ b/README.md
@@ -376,6 +376,7 @@ Documentation for the [uploader](https://github.com/Cap-go/capacitor-uploader)
 * [`setOpacity(...)`](#setopacity)
 * [`stopRecordVideo()`](#stoprecordvideo)
 * [`startRecordVideo(...)`](#startrecordvideo)
+* [`startRecordVideo(...)`](#startrecordvideo)
 * [`setVideoQuality(...)`](#setvideoquality)
 * [`getVideoQuality()`](#getvideoquality)
 * [`getSupportedVideoQualities()`](#getsupportedvideoqualities)
@@ -758,11 +759,26 @@ startRecordVideo(options: CameraPreviewOptions) => Promise<void>
 
 Starts recording a video.
 
+Supports `frameRate`, `maxDuration`, `maxFileSize`, and `videoCodec` on each call.
+
 | Param         | Type                                                                  | Description                        |
 | ------------- | --------------------------------------------------------------------- | ---------------------------------- |
 | **`options`** | <code><a href="#camerapreviewoptions">CameraPreviewOptions</a></code> | - The options for video recording. |
 
 **Since:** 0.0.1
+
+--------------------
+
+
+### startRecordVideo(...)
+
+```typescript
+startRecordVideo(options: CameraPreviewOptions) => Promise<void>
+```
+
+| Param         | Type                                                                  |
+| ------------- | --------------------------------------------------------------------- |
+| **`options`** | <code><a href="#camerapreviewoptions">CameraPreviewOptions</a></code> |
 
 --------------------
 
@@ -1332,7 +1348,8 @@ On Android the actual recording frame rate can still vary in low light or under 
 setVideoFrameRate(options: { frameRate: number; }) => Promise<void>
 ```
 
-Sets the target video frame rate before recording starts.
+Sets the target video frame rate for the active camera session.
+Prefer passing `frameRate` to `startRecordVideo()` when starting a recording.
 Rejects unsupported values with a clear error.
 
 | Param         | Type                                |
@@ -1396,6 +1413,7 @@ Defines the configuration options for starting the camera preview.
 | **`maxDuration`**                   | <code>number</code>                                                                | Maximum recording duration in seconds. Recording stops automatically when reached.                                                                                                                                                  |                        |        |
 | **`maxFileSize`**                   | <code>number</code>                                                                | Maximum recording file size in bytes. Recording stops automatically when reached.                                                                                                                                                   |                        |        |
 | **`videoCodec`**                    | <code><a href="#videocodec">VideoCodec</a></code>                                  | Preferred video codec for recording.                                                                                                                                                                                                | <code>"avc1"</code>    |        |
+| **`frameRate`**                     | <code>number</code>                                                                | Target video frame rate in frames per second. Applied when recording starts. Use `getSupportedVideoFrameRates()` to list supported values.                                                                                          |                        | 8.6.0  |
 | **`barcodeScanner`**                | <code>boolean \| <a href="#barcodescanneroptions">BarcodeScannerOptions</a></code> | Starts barcode scanning together with the camera preview. Set to `true` or pass options to scan all supported formats. Omit this option to keep barcode scanning disabled at startup.                                               |                        | 8.8.0  |
 
 

--- a/android/src/main/java/app/capgo/capacitor/camera/preview/CameraPreview.java
+++ b/android/src/main/java/app/capgo/capacitor/camera/preview/CameraPreview.java
@@ -2839,12 +2839,8 @@ public class CameraPreview extends Plugin implements CameraXView.CameraXViewList
     private void beginVideoRecording(PluginCall call) {
         applyVideoCodecFromCall(call);
         Integer frameRate = call.getInt("frameRate");
-        cameraXView.startRecordVideo(
-            getMaxDurationMillis(call),
-            getMaxFileSize(call),
-            frameRate,
-            call::resolve,
-            message -> call.reject("Failed to start video recording: " + message)
+        cameraXView.startRecordVideo(getMaxDurationMillis(call), getMaxFileSize(call), frameRate, call::resolve, (message) ->
+            call.reject("Failed to start video recording: " + message)
         );
     }
 

--- a/android/src/main/java/app/capgo/capacitor/camera/preview/CameraPreview.java
+++ b/android/src/main/java/app/capgo/capacitor/camera/preview/CameraPreview.java
@@ -2902,12 +2902,20 @@ public class CameraPreview extends Plugin implements CameraXView.CameraXViewList
     }
 
     private void beginVideoRecording(PluginCall call) {
-        applyVideoCodecFromCall(call);
-        applyVideoStabilizationFromCall(call);
-        Integer frameRate = call.getInt("frameRate");
-        cameraXView.startRecordVideo(getMaxDurationMillis(call), getMaxFileSize(call), frameRate, call::resolve, (message) ->
-            call.reject("Failed to start video recording: " + message)
-        );
+        if (cameraXView == null || !cameraXView.isRunning()) {
+            call.reject("Camera is not running");
+            return;
+        }
+        try {
+            applyVideoCodecFromCall(call);
+            applyVideoStabilizationFromCall(call);
+            Integer frameRate = call.getInt("frameRate");
+            cameraXView.startRecordVideo(getMaxDurationMillis(call), getMaxFileSize(call), frameRate, call::resolve, (message) ->
+                call.reject("Failed to start video recording: " + message)
+            );
+        } catch (Exception e) {
+            call.reject("Failed to start video recording: " + e.getMessage());
+        }
     }
 
     @PermissionCallback

--- a/android/src/main/java/app/capgo/capacitor/camera/preview/CameraPreview.java
+++ b/android/src/main/java/app/capgo/capacitor/camera/preview/CameraPreview.java
@@ -291,6 +291,56 @@ public class CameraPreview extends Plugin implements CameraXView.CameraXViewList
     }
 
     @PluginMethod
+    public void getSupportedVideoFrameRates(PluginCall call) {
+        if (cameraXView == null || !cameraXView.isRunning()) {
+            call.reject("Camera is not running");
+            return;
+        }
+        try {
+            List<Integer> frameRates = cameraXView.getSupportedVideoFrameRates();
+            JSObject ret = new JSObject();
+            JSONArray frameRatesArray = new JSONArray();
+            for (Integer frameRate : frameRates) {
+                frameRatesArray.put(frameRate);
+            }
+            ret.put("frameRates", frameRatesArray);
+            call.resolve(ret);
+        } catch (Exception e) {
+            call.reject("Failed to get supported video frame rates: " + e.getMessage());
+        }
+    }
+
+    @PluginMethod
+    public void getVideoFrameRate(PluginCall call) {
+        if (cameraXView == null || !cameraXView.isRunning()) {
+            call.reject("Camera is not running");
+            return;
+        }
+        try {
+            int frameRate = cameraXView.getVideoFrameRate();
+            JSObject ret = new JSObject();
+            ret.put("frameRate", frameRate);
+            call.resolve(ret);
+        } catch (Exception e) {
+            call.reject("Failed to get video frame rate: " + e.getMessage());
+        }
+    }
+
+    @PluginMethod
+    public void setVideoFrameRate(PluginCall call) {
+        if (cameraXView == null || !cameraXView.isRunning()) {
+            call.reject("Camera is not running");
+            return;
+        }
+        Integer frameRate = call.getInt("frameRate");
+        if (frameRate == null) {
+            call.reject("frameRate parameter is required");
+            return;
+        }
+        cameraXView.setVideoFrameRate(frameRate, call::resolve, call::reject);
+    }
+
+    @PluginMethod
     public void getOrientation(PluginCall call) {
         String o = getDeviceOrientationString();
         JSObject ret = new JSObject();

--- a/android/src/main/java/app/capgo/capacitor/camera/preview/CameraPreview.java
+++ b/android/src/main/java/app/capgo/capacitor/camera/preview/CameraPreview.java
@@ -2765,13 +2765,7 @@ public class CameraPreview extends Plugin implements CameraXView.CameraXViewList
         String permissionAlias = disableAudio ? CAMERA_ONLY_PERMISSION_ALIAS : CAMERA_WITH_AUDIO_PERMISSION_ALIAS;
 
         if (PermissionState.GRANTED.equals(getPermissionState(permissionAlias))) {
-            try {
-                applyVideoCodecFromCall(call);
-                cameraXView.startRecordVideo(getMaxDurationMillis(call), getMaxFileSize(call));
-                call.resolve();
-            } catch (Exception e) {
-                call.reject("Failed to start video recording: " + e.getMessage());
-            }
+            beginVideoRecording(call);
         } else {
             requestPermissionForAlias(permissionAlias, call, "handleVideoRecordingPermissionResult");
         }
@@ -2842,6 +2836,18 @@ public class CameraPreview extends Plugin implements CameraXView.CameraXViewList
         return bytes > 0L ? bytes : null;
     }
 
+    private void beginVideoRecording(PluginCall call) {
+        applyVideoCodecFromCall(call);
+        Integer frameRate = call.getInt("frameRate");
+        cameraXView.startRecordVideo(
+            getMaxDurationMillis(call),
+            getMaxFileSize(call),
+            frameRate,
+            call::resolve,
+            message -> call.reject("Failed to start video recording: " + message)
+        );
+    }
+
     @PermissionCallback
     private void handleVideoRecordingPermissionResult(PluginCall call) {
         // Use the persisted session value to determine which permission we requested
@@ -2852,13 +2858,7 @@ public class CameraPreview extends Plugin implements CameraXView.CameraXViewList
             PermissionState.GRANTED.equals(getPermissionState(CAMERA_ONLY_PERMISSION_ALIAS)) ||
             PermissionState.GRANTED.equals(getPermissionState(CAMERA_WITH_AUDIO_PERMISSION_ALIAS))
         ) {
-            try {
-                applyVideoCodecFromCall(call);
-                cameraXView.startRecordVideo(getMaxDurationMillis(call), getMaxFileSize(call));
-                call.resolve();
-            } catch (Exception e) {
-                call.reject("Failed to start video recording: " + e.getMessage());
-            }
+            beginVideoRecording(call);
         } else {
             call.reject("camera permission denied. enable camera access in Settings.", "cameraPermissionDenied");
         }

--- a/android/src/main/java/app/capgo/capacitor/camera/preview/CameraXView.java
+++ b/android/src/main/java/app/capgo/capacitor/camera/preview/CameraXView.java
@@ -4793,6 +4793,30 @@ public class CameraXView implements LifecycleOwner, LifecycleObserver {
         }
     }
 
+    public void startRecordVideo(
+        Long maxDurationMillis,
+        Long maxFileSize,
+        Integer frameRate,
+        Runnable onSuccess,
+        java.util.function.Consumer<String> onError
+    ) {
+        Runnable startRecording = () -> {
+            try {
+                startRecordVideo(maxDurationMillis, maxFileSize);
+                onSuccess.run();
+            } catch (Exception e) {
+                onError.accept(e.getMessage());
+            }
+        };
+
+        if (frameRate == null) {
+            mainExecutor.execute(startRecording);
+            return;
+        }
+
+        setVideoFrameRate(frameRate, startRecording, onError);
+    }
+
     /** @noinspection ResultOfMethodCallIgnored*/
     public void startRecordVideo(Long maxDurationMillis, Long maxFileSize) throws Exception {
         if (videoCapture == null) {

--- a/android/src/main/java/app/capgo/capacitor/camera/preview/CameraXView.java
+++ b/android/src/main/java/app/capgo/capacitor/camera/preview/CameraXView.java
@@ -186,7 +186,9 @@ public class CameraXView implements LifecycleOwner, LifecycleObserver {
     private boolean isRunning = false;
     private Size currentPreviewResolution = null;
     private ListenableFuture<FocusMeteringResult> currentFocusFuture = null; // Track current focus operation
-    private Integer configuredVideoFrameRate = null;
+    private Range<Integer> configuredVideoFrameRateRange = null;
+    private Runnable pendingFrameRateBindSuccess;
+    private java.util.function.Consumer<String> pendingFrameRateBindError;
     private String currentExposureMode = "CONTINUOUS"; // Default behavior
     // Capture/stop coordination
     private final Object captureLock = new Object();
@@ -1296,6 +1298,7 @@ public class CameraXView implements LifecycleOwner, LifecycleObserver {
                 }
 
                 isRunning = true;
+                completePendingFrameRateBindSuccess();
                 Log.d(TAG, "bindCameraUseCases: Camera bound successfully");
                 if (listener != null) {
                     if (sessionConfig != null && sessionConfig.isToBack()) {
@@ -1333,6 +1336,7 @@ public class CameraXView implements LifecycleOwner, LifecycleObserver {
             } catch (Exception e) {
                 // Restore webView background on error
                 restoreWebViewBackground();
+                completePendingFrameRateBindError("Error binding camera: " + e.getMessage());
                 if (listener != null) listener.onCameraStartError(this, "Error binding camera: " + e.getMessage());
             }
         });
@@ -3365,31 +3369,90 @@ public class CameraXView implements LifecycleOwner, LifecycleObserver {
     }
 
     // ===================== Video frame rate APIs =====================
+    private void clearConfiguredVideoFrameRate() {
+        configuredVideoFrameRateRange = null;
+    }
+
+    private Range<Integer>[] getAdvertisedFpsRanges() throws Exception {
+        CameraManager manager = (CameraManager) context.getSystemService(Context.CAMERA_SERVICE);
+        String cameraId = resolveActiveCameraIdForCharacteristics();
+        CameraCharacteristics characteristics = manager.getCameraCharacteristics(cameraId);
+        return characteristics.get(CameraCharacteristics.CONTROL_AE_AVAILABLE_TARGET_FPS_RANGES);
+    }
+
+    private Range<Integer> findAdvertisedFpsRangeForRate(int frameRate, Range<Integer>[] ranges) {
+        if (ranges == null) {
+            return null;
+        }
+
+        Range<Integer> containingRange = null;
+        for (Range<Integer> range : ranges) {
+            if (range.getLower() > frameRate || range.getUpper() < frameRate) {
+                continue;
+            }
+            if (range.getLower().equals(range.getUpper()) && range.getLower() == frameRate) {
+                return range;
+            }
+            containingRange = range;
+        }
+        return containingRange;
+    }
+
+    private Range<Integer> resolveConfiguredVideoFrameRateRange() {
+        if (configuredVideoFrameRateRange == null) {
+            return null;
+        }
+        try {
+            Range<Integer>[] ranges = getAdvertisedFpsRanges();
+            int targetRate = configuredVideoFrameRateRange.getUpper();
+            return findAdvertisedFpsRangeForRate(targetRate, ranges);
+        } catch (Exception e) {
+            Log.w(TAG, "resolveConfiguredVideoFrameRateRange: Failed to resolve FPS range", e);
+            return null;
+        }
+    }
+
+    private void completePendingFrameRateBindSuccess() {
+        if (pendingFrameRateBindSuccess == null) {
+            return;
+        }
+        Runnable callback = pendingFrameRateBindSuccess;
+        pendingFrameRateBindSuccess = null;
+        pendingFrameRateBindError = null;
+        callback.run();
+    }
+
+    private void completePendingFrameRateBindError(String message) {
+        if (pendingFrameRateBindError == null) {
+            return;
+        }
+        java.util.function.Consumer<String> callback = pendingFrameRateBindError;
+        pendingFrameRateBindSuccess = null;
+        pendingFrameRateBindError = null;
+        callback.accept(message);
+    }
+
     @OptIn(markerClass = ExperimentalCamera2Interop.class)
     private Preview.Builder applyTargetFpsToPreviewBuilder(Preview.Builder builder) {
-        if (configuredVideoFrameRate == null) {
+        Range<Integer> fpsRange = resolveConfiguredVideoFrameRateRange();
+        if (fpsRange == null) {
             return builder;
         }
 
         Camera2Interop.Extender<Preview> extender = new Camera2Interop.Extender<>(builder);
-        extender.setCaptureRequestOption(
-            CaptureRequest.CONTROL_AE_TARGET_FPS_RANGE,
-            new Range<>(configuredVideoFrameRate, configuredVideoFrameRate)
-        );
+        extender.setCaptureRequestOption(CaptureRequest.CONTROL_AE_TARGET_FPS_RANGE, fpsRange);
         return builder;
     }
 
     @OptIn(markerClass = ExperimentalCamera2Interop.class)
     private VideoCapture.Builder<Recorder> applyTargetFpsToVideoCaptureBuilder(VideoCapture.Builder<Recorder> builder) {
-        if (configuredVideoFrameRate == null) {
+        Range<Integer> fpsRange = resolveConfiguredVideoFrameRateRange();
+        if (fpsRange == null) {
             return builder;
         }
 
         Camera2Interop.Extender<VideoCapture<Recorder>> extender = new Camera2Interop.Extender<>(builder);
-        extender.setCaptureRequestOption(
-            CaptureRequest.CONTROL_AE_TARGET_FPS_RANGE,
-            new Range<>(configuredVideoFrameRate, configuredVideoFrameRate)
-        );
+        extender.setCaptureRequestOption(CaptureRequest.CONTROL_AE_TARGET_FPS_RANGE, fpsRange);
         return builder;
     }
 
@@ -3432,30 +3495,19 @@ public class CameraXView implements LifecycleOwner, LifecycleObserver {
     }
 
     public List<Integer> getSupportedVideoFrameRates() throws Exception {
-        CameraManager manager = (CameraManager) context.getSystemService(Context.CAMERA_SERVICE);
-        String cameraId = resolveActiveCameraIdForCharacteristics();
-        CameraCharacteristics characteristics = manager.getCameraCharacteristics(cameraId);
-        Range<Integer>[] ranges = characteristics.get(CameraCharacteristics.CONTROL_AE_AVAILABLE_TARGET_FPS_RANGES);
-        return frameRatesFromFpsRanges(ranges);
+        return frameRatesFromFpsRanges(getAdvertisedFpsRanges());
     }
 
     public int getVideoFrameRate() throws Exception {
-        if (configuredVideoFrameRate != null) {
-            return configuredVideoFrameRate;
+        if (configuredVideoFrameRateRange != null) {
+            return configuredVideoFrameRateRange.getUpper();
         }
-
-        CameraManager manager = (CameraManager) context.getSystemService(Context.CAMERA_SERVICE);
-        String cameraId = resolveActiveCameraIdForCharacteristics();
-        CameraCharacteristics characteristics = manager.getCameraCharacteristics(cameraId);
-        Range<Integer>[] ranges = characteristics.get(CameraCharacteristics.CONTROL_AE_AVAILABLE_TARGET_FPS_RANGES);
-        if (ranges == null || ranges.length == 0) {
-            return 30;
-        }
-        return ranges[0].getUpper();
+        return 30;
     }
 
     public void setVideoFrameRate(int frameRate, Runnable onSuccess, java.util.function.Consumer<String> onError) {
         mainExecutor.execute(() -> {
+            Range<Integer> previousRange = configuredVideoFrameRateRange;
             try {
                 if (currentRecording != null) {
                     throw new Exception("Cannot change video frame rate while recording");
@@ -3469,12 +3521,24 @@ public class CameraXView implements LifecycleOwner, LifecycleObserver {
                     throw new Exception("Unsupported frame rate " + frameRate + ". Supported values: " + supportedRates);
                 }
 
-                configuredVideoFrameRate = frameRate;
+                Range<Integer> advertisedRange = findAdvertisedFpsRangeForRate(frameRate, getAdvertisedFpsRanges());
+                if (advertisedRange == null) {
+                    throw new Exception("Unsupported frame rate " + frameRate + " for the active camera");
+                }
+
+                configuredVideoFrameRateRange = advertisedRange;
                 if (isRunning && cameraProvider != null) {
+                    pendingFrameRateBindSuccess = onSuccess;
+                    pendingFrameRateBindError = (message) -> {
+                        configuredVideoFrameRateRange = previousRange;
+                        onError.accept(message);
+                    };
                     bindCameraUseCases();
+                    return;
                 }
                 onSuccess.run();
             } catch (Exception e) {
+                configuredVideoFrameRateRange = previousRange;
                 onError.accept(e.getMessage());
             }
         });
@@ -3771,6 +3835,7 @@ public class CameraXView implements LifecycleOwner, LifecycleObserver {
 
         mainExecutor.execute(() -> {
             try {
+                clearConfiguredVideoFrameRate();
                 CameraSessionConfiguration previousConfig = sessionConfig;
                 CameraInfo targetCameraInfo = findAvailableCameraInfoById(deviceId);
                 String fallbackPosition = resolveFallbackPositionForDeviceId(deviceId);
@@ -3826,6 +3891,7 @@ public class CameraXView implements LifecycleOwner, LifecycleObserver {
 
     public void flipCamera() {
         Log.d(TAG, "flipCamera: Flipping camera");
+        clearConfiguredVideoFrameRate();
 
         // Determine current position based on session config and flip it
         String currentPosition = sessionConfig.getPosition();

--- a/android/src/main/java/app/capgo/capacitor/camera/preview/CameraXView.java
+++ b/android/src/main/java/app/capgo/capacitor/camera/preview/CameraXView.java
@@ -45,8 +45,8 @@ import androidx.annotation.NonNull;
 import androidx.annotation.OptIn;
 import androidx.camera.camera2.interop.Camera2CameraControl;
 import androidx.camera.camera2.interop.Camera2CameraInfo;
-import androidx.camera.camera2.interop.CaptureRequestOptions;
 import androidx.camera.camera2.interop.Camera2Interop;
+import androidx.camera.camera2.interop.CaptureRequestOptions;
 import androidx.camera.camera2.interop.ExperimentalCamera2Interop;
 import androidx.camera.core.AspectRatio;
 import androidx.camera.core.Camera;
@@ -3466,12 +3466,7 @@ public class CameraXView implements LifecycleOwner, LifecycleObserver {
 
                 List<Integer> supportedRates = getSupportedVideoFrameRates();
                 if (!supportedRates.contains(frameRate)) {
-                    throw new Exception(
-                        "Unsupported frame rate " +
-                            frameRate +
-                            ". Supported values: " +
-                            supportedRates
-                    );
+                    throw new Exception("Unsupported frame rate " + frameRate + ". Supported values: " + supportedRates);
                 }
 
                 configuredVideoFrameRate = frameRate;

--- a/android/src/main/java/app/capgo/capacitor/camera/preview/CameraXView.java
+++ b/android/src/main/java/app/capgo/capacitor/camera/preview/CameraXView.java
@@ -46,6 +46,7 @@ import androidx.annotation.OptIn;
 import androidx.camera.camera2.interop.Camera2CameraControl;
 import androidx.camera.camera2.interop.Camera2CameraInfo;
 import androidx.camera.camera2.interop.CaptureRequestOptions;
+import androidx.camera.camera2.interop.Camera2Interop;
 import androidx.camera.camera2.interop.ExperimentalCamera2Interop;
 import androidx.camera.core.AspectRatio;
 import androidx.camera.core.Camera;
@@ -110,6 +111,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.TreeSet;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
@@ -184,6 +186,7 @@ public class CameraXView implements LifecycleOwner, LifecycleObserver {
     private boolean isRunning = false;
     private Size currentPreviewResolution = null;
     private ListenableFuture<FocusMeteringResult> currentFocusFuture = null; // Track current focus operation
+    private Integer configuredVideoFrameRate = null;
     private String currentExposureMode = "CONTINUOUS"; // Default behavior
     // Capture/stop coordination
     private final Object captureLock = new Object();
@@ -1071,7 +1074,11 @@ public class CameraXView implements LifecycleOwner, LifecycleObserver {
                     ? previewView.getDisplay().getRotation()
                     : android.view.Surface.ROTATION_0;
 
-                Preview preview = new Preview.Builder().setResolutionSelector(resolutionSelector).setTargetRotation(rotation).build();
+                Preview.Builder previewBuilder = new Preview.Builder()
+                    .setResolutionSelector(resolutionSelector)
+                    .setTargetRotation(rotation);
+                previewBuilder = applyTargetFpsToPreviewBuilder(previewBuilder);
+                Preview preview = previewBuilder.build();
                 // Keep reference to preview use case for later re-binding (e.g., when enabling video)
                 imageCapture = new ImageCapture.Builder()
                     .setResolutionSelector(resolutionSelector)
@@ -1139,7 +1146,9 @@ public class CameraXView implements LifecycleOwner, LifecycleObserver {
                         recorderBuilder.setVideoCapabilitiesSource(Recorder.VIDEO_CAPABILITIES_SOURCE_CODEC_CAPABILITIES);
                     }
                     Recorder recorder = recorderBuilder.build();
-                    videoCapture = VideoCapture.withOutput(recorder);
+                    VideoCapture.Builder<Recorder> videoCaptureBuilder = new VideoCapture.Builder<>(recorder);
+                    videoCaptureBuilder = applyTargetFpsToVideoCaptureBuilder(videoCaptureBuilder);
+                    videoCapture = videoCaptureBuilder.build();
                 }
 
                 // Unbind any existing use cases and bind new ones
@@ -3353,6 +3362,127 @@ public class CameraXView implements LifecycleOwner, LifecycleObserver {
         } catch (Exception e) {
             Log.w(TAG, "resetExposureCompensationToDefault: Failed to reset exposure compensation", e);
         }
+    }
+
+    // ===================== Video frame rate APIs =====================
+    @OptIn(markerClass = ExperimentalCamera2Interop.class)
+    private Preview.Builder applyTargetFpsToPreviewBuilder(Preview.Builder builder) {
+        if (configuredVideoFrameRate == null) {
+            return builder;
+        }
+
+        Camera2Interop.Extender<Preview> extender = new Camera2Interop.Extender<>(builder);
+        extender.setCaptureRequestOption(
+            CaptureRequest.CONTROL_AE_TARGET_FPS_RANGE,
+            new Range<>(configuredVideoFrameRate, configuredVideoFrameRate)
+        );
+        return builder;
+    }
+
+    @OptIn(markerClass = ExperimentalCamera2Interop.class)
+    private VideoCapture.Builder<Recorder> applyTargetFpsToVideoCaptureBuilder(VideoCapture.Builder<Recorder> builder) {
+        if (configuredVideoFrameRate == null) {
+            return builder;
+        }
+
+        Camera2Interop.Extender<VideoCapture<Recorder>> extender = new Camera2Interop.Extender<>(builder);
+        extender.setCaptureRequestOption(
+            CaptureRequest.CONTROL_AE_TARGET_FPS_RANGE,
+            new Range<>(configuredVideoFrameRate, configuredVideoFrameRate)
+        );
+        return builder;
+    }
+
+    private String resolveActiveCameraIdForCharacteristics() throws Exception {
+        if (currentLogicalDeviceId != null) {
+            return currentLogicalDeviceId;
+        }
+        if (camera != null) {
+            return Camera2CameraInfo.from(camera.getCameraInfo()).getCameraId();
+        }
+        throw new Exception("Camera not initialized");
+    }
+
+    private List<Integer> frameRatesFromFpsRanges(Range<Integer>[] ranges) {
+        TreeSet<Integer> rates = new TreeSet<>();
+        int[] standardRates = new int[] { 24, 25, 30, 50, 60, 120 };
+
+        if (ranges == null) {
+            return new ArrayList<>();
+        }
+
+        for (Range<Integer> range : ranges) {
+            int min = range.getLower();
+            int max = range.getUpper();
+            if (min == max) {
+                rates.add(min);
+                continue;
+            }
+
+            rates.add(min);
+            rates.add(max);
+            for (int standardRate : standardRates) {
+                if (standardRate >= min && standardRate <= max) {
+                    rates.add(standardRate);
+                }
+            }
+        }
+
+        return new ArrayList<>(rates);
+    }
+
+    public List<Integer> getSupportedVideoFrameRates() throws Exception {
+        CameraManager manager = (CameraManager) context.getSystemService(Context.CAMERA_SERVICE);
+        String cameraId = resolveActiveCameraIdForCharacteristics();
+        CameraCharacteristics characteristics = manager.getCameraCharacteristics(cameraId);
+        Range<Integer>[] ranges = characteristics.get(CameraCharacteristics.CONTROL_AE_AVAILABLE_TARGET_FPS_RANGES);
+        return frameRatesFromFpsRanges(ranges);
+    }
+
+    public int getVideoFrameRate() throws Exception {
+        if (configuredVideoFrameRate != null) {
+            return configuredVideoFrameRate;
+        }
+
+        CameraManager manager = (CameraManager) context.getSystemService(Context.CAMERA_SERVICE);
+        String cameraId = resolveActiveCameraIdForCharacteristics();
+        CameraCharacteristics characteristics = manager.getCameraCharacteristics(cameraId);
+        Range<Integer>[] ranges = characteristics.get(CameraCharacteristics.CONTROL_AE_AVAILABLE_TARGET_FPS_RANGES);
+        if (ranges == null || ranges.length == 0) {
+            return 30;
+        }
+        return ranges[0].getUpper();
+    }
+
+    public void setVideoFrameRate(int frameRate, Runnable onSuccess, java.util.function.Consumer<String> onError) {
+        mainExecutor.execute(() -> {
+            try {
+                if (currentRecording != null) {
+                    throw new Exception("Cannot change video frame rate while recording");
+                }
+                if (frameRate <= 0) {
+                    throw new Exception("frameRate must be greater than 0");
+                }
+
+                List<Integer> supportedRates = getSupportedVideoFrameRates();
+                if (!supportedRates.contains(frameRate)) {
+                    throw new Exception(
+                        "Unsupported frame rate " +
+                            frameRate +
+                            ". Supported values: " +
+                            supportedRates
+                    );
+                }
+
+                configuredVideoFrameRate = frameRate;
+                if (isRunning && cameraProvider != null) {
+                    bindCameraUseCases();
+                }
+                onSuccess.run();
+            } catch (Exception e) {
+                onError.accept(e.getMessage());
+            }
+        });
     }
 
     private long showFocusIndicator(float x, float y) {

--- a/android/src/main/java/app/capgo/capacitor/camera/preview/CameraXView.java
+++ b/android/src/main/java/app/capgo/capacitor/camera/preview/CameraXView.java
@@ -186,6 +186,7 @@ public class CameraXView implements LifecycleOwner, LifecycleObserver {
     private boolean isRunning = false;
     private Size currentPreviewResolution = null;
     private ListenableFuture<FocusMeteringResult> currentFocusFuture = null; // Track current focus operation
+    private Integer configuredVideoFrameRate = null;
     private Range<Integer> configuredVideoFrameRateRange = null;
     private Runnable pendingFrameRateBindSuccess;
     private java.util.function.Consumer<String> pendingFrameRateBindError;
@@ -3369,8 +3370,8 @@ public class CameraXView implements LifecycleOwner, LifecycleObserver {
         }
     }
 
-    // ===================== Video frame rate APIs =====================
     private void clearConfiguredVideoFrameRate() {
+        configuredVideoFrameRate = null;
         configuredVideoFrameRateRange = null;
     }
 
@@ -3400,13 +3401,12 @@ public class CameraXView implements LifecycleOwner, LifecycleObserver {
     }
 
     private Range<Integer> resolveConfiguredVideoFrameRateRange() {
-        if (configuredVideoFrameRateRange == null) {
+        if (configuredVideoFrameRate == null) {
             return null;
         }
         try {
             Range<Integer>[] ranges = getAdvertisedFpsRanges();
-            int targetRate = configuredVideoFrameRateRange.getUpper();
-            return findAdvertisedFpsRangeForRate(targetRate, ranges);
+            return findAdvertisedFpsRangeForRate(configuredVideoFrameRate, ranges);
         } catch (Exception e) {
             Log.w(TAG, "resolveConfiguredVideoFrameRateRange: Failed to resolve FPS range", e);
             return null;
@@ -3500,14 +3500,15 @@ public class CameraXView implements LifecycleOwner, LifecycleObserver {
     }
 
     public int getVideoFrameRate() throws Exception {
-        if (configuredVideoFrameRateRange != null) {
-            return configuredVideoFrameRateRange.getUpper();
+        if (configuredVideoFrameRate != null) {
+            return configuredVideoFrameRate;
         }
         return 30;
     }
 
     public void setVideoFrameRate(int frameRate, Runnable onSuccess, java.util.function.Consumer<String> onError) {
         mainExecutor.execute(() -> {
+            Integer previousFrameRate = configuredVideoFrameRate;
             Range<Integer> previousRange = configuredVideoFrameRateRange;
             try {
                 if (currentRecording != null) {
@@ -3527,10 +3528,12 @@ public class CameraXView implements LifecycleOwner, LifecycleObserver {
                     throw new Exception("Unsupported frame rate " + frameRate + " for the active camera");
                 }
 
+                configuredVideoFrameRate = frameRate;
                 configuredVideoFrameRateRange = advertisedRange;
                 if (isRunning && cameraProvider != null) {
                     pendingFrameRateBindSuccess = onSuccess;
                     pendingFrameRateBindError = (message) -> {
+                        configuredVideoFrameRate = previousFrameRate;
                         configuredVideoFrameRateRange = previousRange;
                         onError.accept(message);
                     };
@@ -3539,6 +3542,7 @@ public class CameraXView implements LifecycleOwner, LifecycleObserver {
                 }
                 onSuccess.run();
             } catch (Exception e) {
+                configuredVideoFrameRate = previousFrameRate;
                 configuredVideoFrameRateRange = previousRange;
                 onError.accept(e.getMessage());
             }
@@ -3836,7 +3840,7 @@ public class CameraXView implements LifecycleOwner, LifecycleObserver {
 
         mainExecutor.execute(() -> {
             try {
-                clearConfiguredVideoFrameRate();
+                String previousDeviceId = currentDeviceId;
                 CameraSessionConfiguration previousConfig = sessionConfig;
                 CameraInfo targetCameraInfo = findAvailableCameraInfoById(deviceId);
                 String fallbackPosition = resolveFallbackPositionForDeviceId(deviceId);
@@ -3879,6 +3883,9 @@ public class CameraXView implements LifecycleOwner, LifecycleObserver {
                 );
                 copyMutableSessionConfigState(previousConfig, updatedConfig);
                 updatedConfig.setTargetZoom(1.0f);
+                if (!Objects.equals(deviceId, previousDeviceId)) {
+                    clearConfiguredVideoFrameRate();
+                }
                 sessionConfig = updatedConfig;
 
                 Log.d(TAG, "switchToDevice: Updated sessionConfig with deviceId: " + deviceId);

--- a/ios/Sources/CapgoCameraPreviewPlugin/CameraController.swift
+++ b/ios/Sources/CapgoCameraPreviewPlugin/CameraController.swift
@@ -987,6 +987,7 @@ extension CameraController {
     }
 
     func switchCameras() throws {
+        configuredVideoFrameRate = nil
         guard let currentCameraPosition = currentCameraPosition,
               let captureSession = self.captureSession else {
             throw CameraControllerError.captureSessionIsMissing
@@ -2240,6 +2241,7 @@ extension CameraController {
     }
 
     func cleanup() {
+        configuredVideoFrameRate = nil
         stopBarcodeScanner()
         if let captureSession = self.captureSession {
             captureSession.stopRunning()
@@ -2494,12 +2496,22 @@ extension CameraController {
         return Int(round(Double(duration.timescale) / Double(duration.value)))
     }
 
+    private func allSupportedFrameRates(for device: AVCaptureDevice) -> [Int] {
+        var rates = Set<Int>()
+        for format in device.formats {
+            for rate in frameRates(from: format) {
+                rates.insert(rate)
+            }
+        }
+        return rates.sorted()
+    }
+
     func getSupportedVideoFrameRates() throws -> [Int] {
         guard let device = activeVideoDevice() else {
             throw CameraControllerError.noCamerasAvailable
         }
 
-        return frameRates(from: device.activeFormat)
+        return allSupportedFrameRates(for: device)
     }
 
     func getVideoFrameRate() throws -> Int {
@@ -2527,7 +2539,7 @@ extension CameraController {
             throw CameraControllerError.noCamerasAvailable
         }
 
-        let supportedRates = frameRates(from: device.activeFormat)
+        let supportedRates = allSupportedFrameRates(for: device)
         guard supportedRates.contains(frameRate) else {
             throw NSError(
                 domain: "CameraPreview",
@@ -2536,16 +2548,12 @@ extension CameraController {
             )
         }
 
-        var targetFormat = device.activeFormat
-        if !formatSupportsFrameRate(targetFormat, frameRate: frameRate) {
-            guard let matchingFormat = device.formats.first(where: { formatSupportsFrameRate($0, frameRate: frameRate) }) else {
-                throw NSError(
-                    domain: "CameraPreview",
-                    code: 0,
-                    userInfo: [NSLocalizedDescriptionKey: "Unsupported frame rate \(frameRate) for the active camera"]
-                )
-            }
-            targetFormat = matchingFormat
+        guard let targetFormat = device.formats.first(where: { formatSupportsFrameRate($0, frameRate: frameRate) }) else {
+            throw NSError(
+                domain: "CameraPreview",
+                code: 0,
+                userInfo: [NSLocalizedDescriptionKey: "Unsupported frame rate \(frameRate) for the active camera"]
+            )
         }
 
         let frameDuration = CMTime(value: 1, timescale: CMTimeScale(frameRate))

--- a/ios/Sources/CapgoCameraPreviewPlugin/CameraController.swift
+++ b/ios/Sources/CapgoCameraPreviewPlugin/CameraController.swift
@@ -154,6 +154,7 @@ class CameraController: NSObject {
     private let saneMaxZoomFactor: CGFloat = 25.5
 
     var videoQuality: String = "high"
+    private var configuredVideoFrameRate: Int?
     var videoCodec: String = "avc1"
 
     private static let allVideoQualities = ["low", "medium", "high", "2160p", "1080p", "720p", "480p", "4:3"]
@@ -2442,6 +2443,123 @@ extension CameraController {
             try device.lockForConfiguration()
             device.setExposureTargetBias(clamped) { _ in }
             device.unlockForConfiguration()
+        } catch {
+            throw CameraControllerError.invalidOperation
+        }
+    }
+
+    private func activeVideoDevice() -> AVCaptureDevice? {
+        switch currentCameraPosition {
+        case .front:
+            return self.frontCamera
+        case .rear:
+            return self.rearCamera
+        default:
+            return nil
+        }
+    }
+
+    private func frameRates(from format: AVCaptureDevice.Format) -> [Int] {
+        var rates = Set<Int>()
+        let standardRates = [24, 25, 30, 50, 60, 120]
+
+        for range in format.videoSupportedFrameRateRanges {
+            let minFps = Int(ceil(range.minFrameRate))
+            let maxFps = Int(floor(range.maxFrameRate))
+
+            if minFps == maxFps {
+                rates.insert(minFps)
+                continue
+            }
+
+            rates.insert(minFps)
+            rates.insert(maxFps)
+
+            for rate in standardRates where rate >= minFps && rate <= maxFps {
+                rates.insert(rate)
+            }
+        }
+
+        return rates.sorted()
+    }
+
+    private func formatSupportsFrameRate(_ format: AVCaptureDevice.Format, frameRate: Int) -> Bool {
+        let fps = Double(frameRate)
+        return format.videoSupportedFrameRateRanges.contains { range in
+            fps >= range.minFrameRate && fps <= range.maxFrameRate
+        }
+    }
+
+    private func frameRate(from duration: CMTime) -> Int {
+        guard duration.value > 0 else { return 30 }
+        return Int(round(Double(duration.timescale) / Double(duration.value)))
+    }
+
+    func getSupportedVideoFrameRates() throws -> [Int] {
+        guard let device = activeVideoDevice() else {
+            throw CameraControllerError.noCamerasAvailable
+        }
+
+        return frameRates(from: device.activeFormat)
+    }
+
+    func getVideoFrameRate() throws -> Int {
+        if let configuredVideoFrameRate = self.configuredVideoFrameRate {
+            return configuredVideoFrameRate
+        }
+
+        guard let device = activeVideoDevice() else {
+            throw CameraControllerError.noCamerasAvailable
+        }
+
+        return frameRate(from: device.activeVideoMinFrameDuration)
+    }
+
+    func setVideoFrameRate(_ frameRate: Int) throws {
+        guard frameRate > 0 else {
+            throw NSError(domain: "CameraPreview", code: 0, userInfo: [NSLocalizedDescriptionKey: "frameRate must be greater than 0"])
+        }
+
+        if let fileVideoOutput = self.fileVideoOutput, fileVideoOutput.isRecording {
+            throw NSError(domain: "CameraPreview", code: 0, userInfo: [NSLocalizedDescriptionKey: "Cannot change video frame rate while recording"])
+        }
+
+        guard let device = activeVideoDevice() else {
+            throw CameraControllerError.noCamerasAvailable
+        }
+
+        let supportedRates = frameRates(from: device.activeFormat)
+        guard supportedRates.contains(frameRate) else {
+            throw NSError(
+                domain: "CameraPreview",
+                code: 0,
+                userInfo: [NSLocalizedDescriptionKey: "Unsupported frame rate \(frameRate). Supported values: \(supportedRates.map(String.init).joined(separator: ", "))"]
+            )
+        }
+
+        var targetFormat = device.activeFormat
+        if !formatSupportsFrameRate(targetFormat, frameRate: frameRate) {
+            guard let matchingFormat = device.formats.first(where: { formatSupportsFrameRate($0, frameRate: frameRate) }) else {
+                throw NSError(
+                    domain: "CameraPreview",
+                    code: 0,
+                    userInfo: [NSLocalizedDescriptionKey: "Unsupported frame rate \(frameRate) for the active camera"]
+                )
+            }
+            targetFormat = matchingFormat
+        }
+
+        let frameDuration = CMTime(value: 1, timescale: CMTimeScale(frameRate))
+
+        do {
+            try device.lockForConfiguration()
+            if device.activeFormat != targetFormat {
+                device.activeFormat = targetFormat
+            }
+            device.activeVideoMinFrameDuration = frameDuration
+            device.activeVideoMaxFrameDuration = frameDuration
+            device.unlockForConfiguration()
+            self.configuredVideoFrameRate = frameRate
         } catch {
             throw CameraControllerError.invalidOperation
         }

--- a/ios/Sources/CapgoCameraPreviewPlugin/CameraController.swift
+++ b/ios/Sources/CapgoCameraPreviewPlugin/CameraController.swift
@@ -57,7 +57,6 @@ class CameraController: NSObject {
         }
     }
 
-
     private func setVideoOrientation(_ orientation: AVCaptureVideoOrientation, on connection: AVCaptureConnection) {
         guard connection.isVideoOrientationSupported else { return }
         connection.videoOrientation = orientation

--- a/ios/Sources/CapgoCameraPreviewPlugin/Plugin.swift
+++ b/ios/Sources/CapgoCameraPreviewPlugin/Plugin.swift
@@ -86,6 +86,9 @@ public class CameraPreview: CAPPlugin, CAPBridgedPlugin, CLLocationManagerDelega
         CAPPluginMethod(name: "getExposureCompensationRange", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "getExposureCompensation", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "setExposureCompensation", returnType: CAPPluginReturnPromise),
+        CAPPluginMethod(name: "getSupportedVideoFrameRates", returnType: CAPPluginReturnPromise),
+        CAPPluginMethod(name: "getVideoFrameRate", returnType: CAPPluginReturnPromise),
+        CAPPluginMethod(name: "setVideoFrameRate", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "getPluginVersion", returnType: CAPPluginReturnPromise)
     ]
     // Camera state tracking
@@ -2433,6 +2436,49 @@ public class CameraPreview: CAPPlugin, CAPBridgedPlugin, CLLocationManagerDelega
             call.resolve()
         } catch {
             call.reject("Failed to set exposure compensation: \(error.localizedDescription)")
+        }
+    }
+
+    @objc func getSupportedVideoFrameRates(_ call: CAPPluginCall) {
+        guard isInitialized else {
+            call.reject("Camera not initialized")
+            return
+        }
+        do {
+            let frameRates = try self.cameraController.getSupportedVideoFrameRates()
+            call.resolve(["frameRates": frameRates])
+        } catch {
+            call.reject("Failed to get supported video frame rates: \(error.localizedDescription)")
+        }
+    }
+
+    @objc func getVideoFrameRate(_ call: CAPPluginCall) {
+        guard isInitialized else {
+            call.reject("Camera not initialized")
+            return
+        }
+        do {
+            let frameRate = try self.cameraController.getVideoFrameRate()
+            call.resolve(["frameRate": frameRate])
+        } catch {
+            call.reject("Failed to get video frame rate: \(error.localizedDescription)")
+        }
+    }
+
+    @objc func setVideoFrameRate(_ call: CAPPluginCall) {
+        guard isInitialized else {
+            call.reject("Camera not initialized")
+            return
+        }
+        guard let frameRate = call.getInt("frameRate") else {
+            call.reject("frameRate parameter is required")
+            return
+        }
+        do {
+            try self.cameraController.setVideoFrameRate(frameRate)
+            call.resolve()
+        } catch {
+            call.reject(error.localizedDescription)
         }
     }
 

--- a/ios/Sources/CapgoCameraPreviewPlugin/Plugin.swift
+++ b/ios/Sources/CapgoCameraPreviewPlugin/Plugin.swift
@@ -1659,6 +1659,9 @@ public class CameraPreview: CAPPlugin, CAPBridgedPlugin, CLLocationManagerDelega
         }
 
         do {
+            if let frameRate = call.getInt("frameRate") {
+                try self.cameraController.setVideoFrameRate(frameRate)
+            }
             try self.cameraController.captureVideo(maxDuration: maxDuration, maxFileSize: maxFileSize)
             call.resolve()
         } catch {

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -347,6 +347,13 @@ export interface CameraPreviewOptions {
    */
   videoCodec?: VideoCodec;
   /**
+   * Target video frame rate in frames per second.
+   * Applied when recording starts. Use `getSupportedVideoFrameRates()` to list supported values.
+   * @platform ios, android
+   * @since 8.6.0
+   */
+  frameRate?: number;
+  /**
    * Starts barcode scanning together with the camera preview.
    * Set to `true` or pass options to scan all supported formats.
    * Omit this option to keep barcode scanning disabled at startup.
@@ -706,10 +713,13 @@ export interface CameraPreviewPlugin {
   /**
    * Starts recording a video.
    *
+   * Supports `frameRate`, `maxDuration`, `maxFileSize`, and `videoCodec` on each call.
+   *
    * @param {CameraPreviewOptions} options - The options for video recording.
    * @returns {Promise<void>} A promise that resolves when video recording starts.
    * @since 0.0.1
    */
+  startRecordVideo(options: CameraPreviewOptions): Promise<void>;
   startRecordVideo(options: CameraPreviewOptions): Promise<void>;
 
   /**
@@ -1049,7 +1059,8 @@ export interface CameraPreviewPlugin {
   }>;
 
   /**
-   * Sets the target video frame rate before recording starts.
+   * Sets the target video frame rate for the active camera session.
+   * Prefer passing `frameRate` to `startRecordVideo()` when starting a recording.
    * Rejects unsupported values with a clear error.
    *
    * @platform android, ios

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -1027,6 +1027,37 @@ export interface CameraPreviewPlugin {
   setExposureCompensation(options: { value: number }): Promise<void>;
 
   /**
+   * Lists the video frame rates supported by the active camera for the current format.
+   * Supported values depend on the selected camera, lens, and video quality.
+   *
+   * @platform android, ios
+   * @since 8.6.0
+   */
+  getSupportedVideoFrameRates(): Promise<{
+    frameRates: number[];
+  }>;
+
+  /**
+   * Returns the configured video frame rate for the active camera.
+   * On Android the actual recording frame rate can still vary in low light or under thermal pressure.
+   *
+   * @platform android, ios
+   * @since 8.6.0
+   */
+  getVideoFrameRate(): Promise<{
+    frameRate: number;
+  }>;
+
+  /**
+   * Sets the target video frame rate before recording starts.
+   * Rejects unsupported values with a clear error.
+   *
+   * @platform android, ios
+   * @since 8.6.0
+   */
+  setVideoFrameRate(options: { frameRate: number }): Promise<void>;
+
+  /**
    * Get the native Capacitor plugin version
    *
    * @returns {Promise<{ id: string }>} an Promise with version for this device

--- a/src/web.ts
+++ b/src/web.ts
@@ -1546,6 +1546,19 @@ export class CameraPreviewWeb extends WebPlugin implements CameraPreviewPlugin {
     throw new Error('setExposureCompensation not supported under the web platform');
   }
 
+  async getSupportedVideoFrameRates(): Promise<{ frameRates: number[] }> {
+    throw new Error('getSupportedVideoFrameRates not supported under the web platform');
+  }
+
+  async getVideoFrameRate(): Promise<{ frameRate: number }> {
+    throw new Error('getVideoFrameRate not supported under the web platform');
+  }
+
+  async setVideoFrameRate(_options: { frameRate: number }): Promise<void> {
+    void _options;
+    throw new Error('setVideoFrameRate not supported under the web platform');
+  }
+
   async deleteFile(_options: { path: string }): Promise<{ success: boolean }> {
     // Mark parameter as intentionally unused to satisfy linter
     void _options;


### PR DESCRIPTION
## Summary
- Adds `getSupportedVideoFrameRates()`, `getVideoFrameRate()`, and `setVideoFrameRate({ frameRate })` to the TypeScript API with docgen updates.
- **iOS**: enumerates rates from `AVCaptureDevice.Format.videoSupportedFrameRateRanges`, reads the configured rate from `activeVideoMinFrameDuration`, and applies a requested rate via `activeVideoMinFrameDuration` / `activeVideoMaxFrameDuration` before recording.
- **Android**: reads supported ranges from `CONTROL_AE_AVAILABLE_TARGET_FPS_RANGES`, applies `CONTROL_AE_TARGET_FPS_RANGE` through Camera2Interop on Preview/VideoCapture bind, and rebinds the session when the target rate changes.

## Test plan
- [x] `bun run verify:android`
- [x] `bun run verify:web`
- [ ] `bun run verify:ios` (blocked locally: iOS 26.4 platform not installed in Xcode)
- [ ] On device: start camera with `enableVideoMode: true`, call `getSupportedVideoFrameRates()`, set a supported rate with `setVideoFrameRate()`, verify `getVideoFrameRate()` returns it, then record video
- [ ] Confirm `setVideoFrameRate` rejects unsupported values and rejects changes while recording is active


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
- Added video frame-rate management for camera preview/video recording
  - Query supported FPS values
  - Retrieve the currently configured FPS
  - Set a target FPS (applied when recording starts, and when supported while running)
- Added `frameRate` to camera preview/recording options (since 8.6.0)
- Android and iOS support for frame-rate control (since 8.6.0); unsupported platforms reject with “not supported under the web platform”
- Unsupported FPS values are rejected automatically

## Documentation
- Updated README/API docs for the new frame-rate methods and `frameRate` option.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->