### PR TITLE
feat: video stabilization controls (closes #370)

### DIFF
--- a/README.md
+++ b/README.md
@@ -759,9 +759,9 @@ startRecordVideo(options: CameraPreviewOptions) => Promise<void>
 
 Starts recording a video.
 
-| Param         | Type                                                                  | Description                        |
-| ------------- | --------------------------------------------------------------------- | ---------------------------------- |
-| **`options`** | <code><a href="#camerapreviewoptions">CameraPreviewOptions</a></code> | - The options for video recording. |
+| Param         | Type                                                                  | Description                                                                                                                           |
+| ------------- | --------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
+| **`options`** | <code><a href="#camerapreviewoptions">CameraPreviewOptions</a></code> | - The options for video recording. Supports `videoCodec`, `videoStabilizationMode`, `maxDuration`, `maxFileSize`, and `disableAudio`. |
 
 **Since:** 0.0.1
 
@@ -915,6 +915,7 @@ setVideoStabilizationMode(options: { mode: VideoStabilizationMode; }) => Promise
 
 Sets the video stabilization mode for recording.
 Cannot be changed while a recording is in progress.
+You can also pass `videoStabilizationMode` in `startRecordVideo()` options.
 
 | Param         | Type                                                                                 | Description                       |
 | ------------- | ------------------------------------------------------------------------------------ | --------------------------------- |
@@ -1410,6 +1411,7 @@ Defines the configuration options for starting the camera preview.
 | **`maxDuration`**                   | <code>number</code>                                                                | Maximum recording duration in seconds. Recording stops automatically when reached.                                                                                                                                                  |                        |        |
 | **`maxFileSize`**                   | <code>number</code>                                                                | Maximum recording file size in bytes. Recording stops automatically when reached.                                                                                                                                                   |                        |        |
 | **`videoCodec`**                    | <code><a href="#videocodec">VideoCodec</a></code>                                  | Preferred video codec for recording.                                                                                                                                                                                                | <code>"avc1"</code>    |        |
+| **`videoStabilizationMode`**        | <code><a href="#videostabilizationmode">VideoStabilizationMode</a></code>          | Preferred video stabilization mode for recording.                                                                                                                                                                                   | <code>"off"</code>     |        |
 | **`barcodeScanner`**                | <code>boolean \| <a href="#barcodescanneroptions">BarcodeScannerOptions</a></code> | Starts barcode scanning together with the camera preview. Set to `true` or pass options to scan all supported formats. Omit this option to keep barcode scanning disabled at startup.                                               |                        | 8.8.0  |
 
 
@@ -1630,6 +1632,16 @@ Video codec identifiers used when recording.
 <code>'avc1' | 'hvc1' | 'jpeg' | 'apcn' | 'ap4h'</code>
 
 
+#### VideoStabilizationMode
+
+Video stabilization modes used when recording.
+
+On Android only `off` and `standard` are supported.
+On iOS all listed modes may be available when the device supports video stabilization.
+
+<code>'off' | 'standard' | 'cinematic' | 'cinematicExtended' | 'previewOptimized' | 'cinematicExtendedEnhanced' | 'auto' | 'lowLatency'</code>
+
+
 #### BarcodeScannerFormat
 
 <code>'aztec' | 'codabar' | 'code_39' | 'code_93' | 'code_128' | 'data_matrix' | 'ean_8' | 'ean_13' | 'itf' | 'pdf417' | 'qr_code' | 'upc_a' | 'upc_e'</code>
@@ -1663,16 +1675,6 @@ From T, pick a set of properties whose keys are in the union K
 #### RecordingFinishedReason
 
 <code>'manual' | 'maxDuration' | 'maxFileSize'</code>
-
-
-#### VideoStabilizationMode
-
-Video stabilization modes used when recording.
-
-On Android only `off` and `standard` are supported.
-On iOS all listed modes may be available when the device supports video stabilization.
-
-<code>'off' | 'standard' | 'cinematic' | 'cinematicExtended' | 'previewOptimized' | 'cinematicExtendedEnhanced' | 'auto' | 'lowLatency'</code>
 
 
 #### FlashMode

--- a/README.md
+++ b/README.md
@@ -382,6 +382,10 @@ Documentation for the [uploader](https://github.com/Cap-go/capacitor-uploader)
 * [`setVideoCodec(...)`](#setvideocodec)
 * [`getVideoCodec()`](#getvideocodec)
 * [`getSupportedVideoCodecs()`](#getsupportedvideocodecs)
+* [`isVideoStabilizationSupported()`](#isvideostabilizationsupported)
+* [`getSupportedVideoStabilizationModes()`](#getsupportedvideostabilizationmodes)
+* [`getVideoStabilizationMode()`](#getvideostabilizationmode)
+* [`setVideoStabilizationMode(...)`](#setvideostabilizationmode)
 * [`isRunning()`](#isrunning)
 * [`getAvailableDevices()`](#getavailabledevices)
 * [`getZoom()`](#getzoom)
@@ -854,6 +858,69 @@ Returns the video codecs supported by the active camera.
 **Returns:** <code>Promise&lt;{ codecs: VideoCodec[]; }&gt;</code>
 
 **Since:** 8.5.0
+
+--------------------
+
+
+### isVideoStabilizationSupported()
+
+```typescript
+isVideoStabilizationSupported() => Promise<{ supported: boolean; }>
+```
+
+Checks whether video stabilization is supported by the active camera.
+
+**Returns:** <code>Promise&lt;{ supported: boolean; }&gt;</code>
+
+**Since:** 8.5.2
+
+--------------------
+
+
+### getSupportedVideoStabilizationModes()
+
+```typescript
+getSupportedVideoStabilizationModes() => Promise<{ modes: VideoStabilizationMode[]; }>
+```
+
+Returns the video stabilization modes supported by the active camera.
+
+**Returns:** <code>Promise&lt;{ modes: VideoStabilizationMode[]; }&gt;</code>
+
+**Since:** 8.5.2
+
+--------------------
+
+
+### getVideoStabilizationMode()
+
+```typescript
+getVideoStabilizationMode() => Promise<{ mode: VideoStabilizationMode; }>
+```
+
+Gets the current video stabilization mode.
+
+**Returns:** <code>Promise&lt;{ mode: <a href="#videostabilizationmode">VideoStabilizationMode</a>; }&gt;</code>
+
+**Since:** 8.5.2
+
+--------------------
+
+
+### setVideoStabilizationMode(...)
+
+```typescript
+setVideoStabilizationMode(options: { mode: VideoStabilizationMode; }) => Promise<void>
+```
+
+Sets the video stabilization mode for recording.
+Cannot be changed while a recording is in progress.
+
+| Param         | Type                                                                                 | Description                       |
+| ------------- | ------------------------------------------------------------------------------------ | --------------------------------- |
+| **`options`** | <code>{ mode: <a href="#videostabilizationmode">VideoStabilizationMode</a>; }</code> | - The desired stabilization mode. |
+
+**Since:** 8.5.2
 
 --------------------
 
@@ -1596,6 +1663,16 @@ From T, pick a set of properties whose keys are in the union K
 #### RecordingFinishedReason
 
 <code>'manual' | 'maxDuration' | 'maxFileSize'</code>
+
+
+#### VideoStabilizationMode
+
+Video stabilization modes used when recording.
+
+On Android only `off` and `standard` are supported.
+On iOS all listed modes may be available when the device supports video stabilization.
+
+<code>'off' | 'standard' | 'cinematic' | 'cinematicExtended' | 'previewOptimized' | 'cinematicExtendedEnhanced' | 'auto' | 'lowLatency'</code>
 
 
 #### FlashMode

--- a/android/src/main/java/app/capgo/capacitor/camera/preview/CameraPreview.java
+++ b/android/src/main/java/app/capgo/capacitor/camera/preview/CameraPreview.java
@@ -52,6 +52,7 @@ import com.google.android.gms.location.FusedLocationProviderClient;
 import com.google.android.gms.location.LocationServices;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
@@ -2699,6 +2700,63 @@ public class CameraPreview extends Plugin implements CameraXView.CameraXViewList
         JSObject ret = new JSObject();
         ret.put("codecs", arr);
         call.resolve(ret);
+    }
+
+    @PluginMethod
+    public void isVideoStabilizationSupported(PluginCall call) {
+        if (cameraXView == null || !cameraXView.isRunning()) {
+            call.reject("Camera is not running");
+            return;
+        }
+        JSObject ret = new JSObject();
+        ret.put("supported", cameraXView.isVideoStabilizationSupported());
+        call.resolve(ret);
+    }
+
+    @PluginMethod
+    public void getSupportedVideoStabilizationModes(PluginCall call) {
+        List<String> modes = cameraXView != null ? cameraXView.getSupportedVideoStabilizationModes() : Collections.singletonList("off");
+        JSONArray arr = new JSONArray();
+        for (String mode : modes) {
+            arr.put(mode);
+        }
+        JSObject ret = new JSObject();
+        ret.put("modes", arr);
+        call.resolve(ret);
+    }
+
+    @PluginMethod
+    public void getVideoStabilizationMode(PluginCall call) {
+        if (cameraXView == null || !cameraXView.isRunning()) {
+            call.reject("Camera is not running");
+            return;
+        }
+        JSObject ret = new JSObject();
+        ret.put("mode", cameraXView.getVideoStabilizationModeSetting());
+        call.resolve(ret);
+    }
+
+    @PluginMethod
+    public void setVideoStabilizationMode(PluginCall call) {
+        if (cameraXView == null || !cameraXView.isRunning()) {
+            call.reject("Camera is not running");
+            return;
+        }
+        String mode = call.getString("mode");
+        if (mode == null) {
+            call.reject("mode is required");
+            return;
+        }
+        try {
+            cameraXView.setVideoStabilizationModeSetting(mode);
+            call.resolve();
+        } catch (IllegalArgumentException e) {
+            call.reject(e.getMessage());
+        } catch (IllegalStateException e) {
+            call.reject(e.getMessage());
+        } catch (Exception e) {
+            call.reject("Failed to set video stabilization mode: " + e.getMessage());
+        }
     }
 
     @PluginMethod

--- a/android/src/main/java/app/capgo/capacitor/camera/preview/CameraPreview.java
+++ b/android/src/main/java/app/capgo/capacitor/camera/preview/CameraPreview.java
@@ -2775,6 +2775,7 @@ public class CameraPreview extends Plugin implements CameraXView.CameraXViewList
         if (PermissionState.GRANTED.equals(getPermissionState(permissionAlias))) {
             try {
                 applyVideoCodecFromCall(call);
+                applyVideoStabilizationFromCall(call);
                 cameraXView.startRecordVideo(getMaxDurationMillis(call), getMaxFileSize(call));
                 call.resolve();
             } catch (Exception e) {
@@ -2831,6 +2832,13 @@ public class CameraPreview extends Plugin implements CameraXView.CameraXViewList
         }
     }
 
+    private void applyVideoStabilizationFromCall(PluginCall call) {
+        String mode = call.getString("videoStabilizationMode");
+        if (mode != null && cameraXView != null) {
+            cameraXView.setVideoStabilizationModeSetting(mode);
+        }
+    }
+
     private Long getMaxDurationMillis(PluginCall call) {
         if (!call.getData().has("maxDuration") || call.getData().isNull("maxDuration")) {
             return null;
@@ -2862,6 +2870,7 @@ public class CameraPreview extends Plugin implements CameraXView.CameraXViewList
         ) {
             try {
                 applyVideoCodecFromCall(call);
+                applyVideoStabilizationFromCall(call);
                 cameraXView.startRecordVideo(getMaxDurationMillis(call), getMaxFileSize(call));
                 call.resolve();
             } catch (Exception e) {

--- a/android/src/main/java/app/capgo/capacitor/camera/preview/CameraXView.java
+++ b/android/src/main/java/app/capgo/capacitor/camera/preview/CameraXView.java
@@ -1139,7 +1139,9 @@ public class CameraXView implements LifecycleOwner, LifecycleObserver {
                         recorderBuilder.setVideoCapabilitiesSource(Recorder.VIDEO_CAPABILITIES_SOURCE_CODEC_CAPABILITIES);
                     }
                     Recorder recorder = recorderBuilder.build();
-                    videoCapture = VideoCapture.withOutput(recorder);
+                    VideoCapture.Builder<Recorder> videoCaptureBuilder = new VideoCapture.Builder<>(recorder);
+                    videoCaptureBuilder.setVideoStabilizationEnabled(isVideoStabilizationEnabledForSession());
+                    videoCapture = videoCaptureBuilder.build();
                 }
 
                 // Unbind any existing use cases and bind new ones
@@ -4785,6 +4787,15 @@ public class CameraXView implements LifecycleOwner, LifecycleObserver {
     private static final List<String> ALL_VIDEO_QUALITIES = Arrays.asList("low", "medium", "high", "2160p", "1080p", "720p", "480p", "4:3");
 
     private static final List<String> ALL_VIDEO_CODECS = Arrays.asList("avc1", "hvc1");
+    private static final List<String> ALL_VIDEO_STABILIZATION_MODES = Arrays.asList("off", "standard");
+    private static final List<String> IOS_ONLY_VIDEO_STABILIZATION_MODES = Arrays.asList(
+        "cinematic",
+        "cinematicExtended",
+        "previewOptimized",
+        "cinematicExtendedEnhanced",
+        "auto",
+        "lowLatency"
+    );
 
     public String getVideoQualitySetting() {
         if (sessionConfig == null) {
@@ -4861,6 +4872,88 @@ public class CameraXView implements LifecycleOwner, LifecycleObserver {
                     return true;
                 }
             }
+        }
+        return false;
+    }
+
+    public boolean isVideoStabilizationSupported() {
+        return isStandardVideoStabilizationSupported();
+    }
+
+    public List<String> getSupportedVideoStabilizationModes() {
+        List<String> modes = new ArrayList<>();
+        modes.add("off");
+        if (isStandardVideoStabilizationSupported()) {
+            modes.add("standard");
+        }
+        return modes;
+    }
+
+    public String getVideoStabilizationModeSetting() {
+        if (sessionConfig == null) {
+            return "off";
+        }
+        return sessionConfig.getVideoStabilizationMode();
+    }
+
+    public void setVideoStabilizationModeSetting(String mode) {
+        if (sessionConfig == null) {
+            throw new IllegalStateException("Camera session is not running");
+        }
+        if (currentRecording != null) {
+            throw new IllegalStateException("Cannot change video stabilization while recording is in progress");
+        }
+        String normalized = mode != null ? mode : "off";
+        if (IOS_ONLY_VIDEO_STABILIZATION_MODES.contains(normalized)) {
+            throw new IllegalArgumentException(
+                "Video stabilization mode '" + normalized + "' is only supported on iOS. Use 'off' or 'standard' on Android."
+            );
+        }
+        if (!ALL_VIDEO_STABILIZATION_MODES.contains(normalized)) {
+            throw new IllegalArgumentException("Unsupported video stabilization mode: " + mode);
+        }
+        if ("standard".equals(normalized) && !isStandardVideoStabilizationSupported()) {
+            throw new IllegalArgumentException("Video stabilization mode 'standard' is not supported on this device");
+        }
+        if (normalized.equals(sessionConfig.getVideoStabilizationMode())) {
+            return;
+        }
+        sessionConfig.setVideoStabilizationMode(normalized);
+        if (sessionConfig.isVideoModeEnabled() && isRunning) {
+            mainExecutor.execute(this::bindCameraUseCases);
+        }
+    }
+
+    private boolean isVideoStabilizationEnabledForSession() {
+        if (sessionConfig == null) {
+            return false;
+        }
+        return "standard".equalsIgnoreCase(sessionConfig.getVideoStabilizationMode());
+    }
+
+    private boolean isStandardVideoStabilizationSupported() {
+        if (camera == null) {
+            return false;
+        }
+        try {
+            String cameraId = Camera2CameraInfo.from(camera.getCameraInfo()).getCameraId();
+            CameraManager cameraManager = (CameraManager) context.getSystemService(Context.CAMERA_SERVICE);
+            if (cameraManager == null) {
+                return false;
+            }
+            int[] modes = cameraManager
+                .getCameraCharacteristics(cameraId)
+                .get(CameraCharacteristics.CONTROL_AVAILABLE_VIDEO_STABILIZATION_MODES);
+            if (modes == null) {
+                return false;
+            }
+            for (int availableMode : modes) {
+                if (availableMode == CaptureRequest.CONTROL_VIDEO_STABILIZATION_MODE_ON) {
+                    return true;
+                }
+            }
+        } catch (CameraAccessException e) {
+            Log.w(TAG, "Failed to read video stabilization modes", e);
         }
         return false;
     }

--- a/android/src/main/java/app/capgo/capacitor/camera/preview/model/CameraSessionConfiguration.java
+++ b/android/src/main/java/app/capgo/capacitor/camera/preview/model/CameraSessionConfiguration.java
@@ -27,6 +27,7 @@ public class CameraSessionConfiguration {
     private boolean isCentered = false;
     private String videoQuality;
     private String videoCodec = "avc1";
+    private String videoStabilizationMode = "off";
     private boolean enablePhysicalDeviceSelection = false;
     private boolean barcodeScannerEnabled = false;
 
@@ -158,6 +159,14 @@ public class CameraSessionConfiguration {
 
     public void setVideoCodec(String codec) {
         this.videoCodec = codec != null ? codec : "avc1";
+    }
+
+    public String getVideoStabilizationMode() {
+        return videoStabilizationMode;
+    }
+
+    public void setVideoStabilizationMode(String mode) {
+        this.videoStabilizationMode = mode != null ? mode : "off";
     }
 
     public boolean isPhysicalDeviceSelectionEnabled() {

--- a/ios/Sources/CapgoCameraPreviewPlugin/CameraController.swift
+++ b/ios/Sources/CapgoCameraPreviewPlugin/CameraController.swift
@@ -57,7 +57,6 @@ class CameraController: NSObject {
         }
     }
 
-
     private func setVideoOrientation(_ orientation: AVCaptureVideoOrientation, on connection: AVCaptureConnection) {
         guard connection.isVideoOrientationSupported else { return }
         connection.videoOrientation = orientation
@@ -155,6 +154,7 @@ class CameraController: NSObject {
 
     var videoQuality: String = "high"
     var videoCodec: String = "avc1"
+    var videoStabilizationMode: String = "off"
 
     private static let allVideoQualities = ["low", "medium", "high", "2160p", "1080p", "720p", "480p", "4:3"]
 
@@ -211,6 +211,145 @@ class CameraController: NSObject {
 
     func getVideoCodec() -> String {
         return self.videoCodec
+    }
+
+    func isVideoStabilizationSupported() -> Bool {
+        guard let connection = self.fileVideoOutput?.connection(with: .video) else {
+            return false
+        }
+        return connection.isVideoStabilizationSupported
+    }
+
+    func getSupportedVideoStabilizationModes() -> [String] {
+        guard let connection = self.fileVideoOutput?.connection(with: .video),
+              connection.isVideoStabilizationSupported else {
+            return ["off"]
+        }
+
+        let savedPreferred = connection.preferredVideoStabilizationMode
+        var supported: [String] = []
+
+        for candidate in Self.allVideoStabilizationModeCandidates() {
+            connection.preferredVideoStabilizationMode = candidate.mode
+            if connection.preferredVideoStabilizationMode == candidate.mode {
+                supported.append(candidate.name)
+            }
+        }
+
+        connection.preferredVideoStabilizationMode = savedPreferred
+        return supported.isEmpty ? ["off"] : supported
+    }
+
+    func getVideoStabilizationMode() -> String {
+        if let connection = self.fileVideoOutput?.connection(with: .video),
+           connection.isVideoStabilizationSupported {
+            return self.videoStabilizationModeString(from: connection.activeVideoStabilizationMode)
+        }
+        return self.videoStabilizationMode
+    }
+
+    func setVideoStabilizationMode(_ mode: String) throws {
+        if self.fileVideoOutput?.isRecording == true {
+            throw CameraControllerError.recordingInProgress
+        }
+        guard let avMode = self.avVideoStabilizationMode(from: mode) else {
+            throw CameraControllerError.invalidOperation
+        }
+        let supportedModes = self.getSupportedVideoStabilizationModes()
+        guard supportedModes.contains(mode) else {
+            throw CameraControllerError.invalidOperation
+        }
+        self.videoStabilizationMode = mode
+        self.applyVideoStabilizationMode(avMode)
+    }
+
+    private static func allVideoStabilizationModeCandidates() -> [(name: String, mode: AVCaptureVideoStabilizationMode)] {
+        var candidates: [(String, AVCaptureVideoStabilizationMode)] = [
+            ("off", .off),
+            ("standard", .standard),
+            ("cinematic", .cinematic),
+            ("cinematicExtended", .cinematicExtended),
+            ("auto", .auto),
+        ]
+        if #available(iOS 17.0, *) {
+            candidates.append(("previewOptimized", .previewOptimized))
+            candidates.append(("cinematicExtendedEnhanced", .cinematicExtendedEnhanced))
+        }
+        if #available(iOS 18.0, *) {
+            candidates.append(("lowLatency", .lowLatency))
+        }
+        return candidates
+    }
+
+    private func applyVideoStabilizationMode(_ mode: AVCaptureVideoStabilizationMode? = nil) {
+        guard let connection = self.fileVideoOutput?.connection(with: .video),
+              connection.isVideoStabilizationSupported else {
+            return
+        }
+        let targetMode = mode ?? self.avVideoStabilizationMode(from: self.videoStabilizationMode) ?? .off
+        connection.preferredVideoStabilizationMode = targetMode
+    }
+
+    private func avVideoStabilizationMode(from mode: String) -> AVCaptureVideoStabilizationMode? {
+        switch mode {
+        case "off":
+            return .off
+        case "standard":
+            return .standard
+        case "cinematic":
+            return .cinematic
+        case "cinematicExtended":
+            return .cinematicExtended
+        case "auto":
+            return .auto
+        case "previewOptimized":
+            if #available(iOS 17.0, *) {
+                return .previewOptimized
+            }
+            return nil
+        case "cinematicExtendedEnhanced":
+            if #available(iOS 17.0, *) {
+                return .cinematicExtendedEnhanced
+            }
+            return nil
+        case "lowLatency":
+            if #available(iOS 18.0, *) {
+                return .lowLatency
+            }
+            return nil
+        default:
+            return nil
+        }
+    }
+
+    private func videoStabilizationModeString(from mode: AVCaptureVideoStabilizationMode) -> String {
+        switch mode {
+        case .off:
+            return "off"
+        case .standard:
+            return "standard"
+        case .cinematic:
+            return "cinematic"
+        case .cinematicExtended:
+            return "cinematicExtended"
+        case .auto:
+            return "auto"
+        default:
+            if #available(iOS 17.0, *) {
+                if mode == .previewOptimized {
+                    return "previewOptimized"
+                }
+                if mode == .cinematicExtendedEnhanced {
+                    return "cinematicExtendedEnhanced"
+                }
+            }
+            if #available(iOS 18.0, *) {
+                if mode == .lowLatency {
+                    return "lowLatency"
+                }
+            }
+            return self.videoStabilizationMode
+        }
     }
 
     private func avVideoCodecType(for codec: String) -> AVVideoCodecType? {
@@ -515,6 +654,7 @@ extension CameraController {
                     captureSession.addOutput(fileVideoOutput)
                     // Set orientation immediately
                     self.setVideoOrientation(videoOrientation, on: fileVideoOutput.connections)
+                    self.applyVideoStabilizationMode()
                 }
 
                 // Set up preview layer session in the same configuration block
@@ -1094,6 +1234,7 @@ extension CameraController {
             captureSession.removeOutput(fileVideoOutput)
             if captureSession.canAddOutput(fileVideoOutput) {
                 captureSession.addOutput(fileVideoOutput)
+                self.applyVideoStabilizationMode()
             }
         }
 
@@ -2479,6 +2620,7 @@ extension CameraController {
             captureSession.beginConfiguration()
             if captureSession.canAddOutput(fileVideoOutput) {
                 captureSession.addOutput(fileVideoOutput)
+                self.applyVideoStabilizationMode()
             } else {
                 captureSession.commitConfiguration()
                 throw CameraControllerError.invalidOperation
@@ -2519,6 +2661,8 @@ extension CameraController {
            fileVideoOutput.availableVideoCodecTypes.contains(codecType) {
             fileVideoOutput.setOutputSettings([AVVideoCodecKey: codecType], for: connection)
         }
+
+        self.applyVideoStabilizationMode()
 
         // Start recording video
         fileVideoOutput.startRecording(to: fileUrl, recordingDelegate: self)
@@ -2824,6 +2968,7 @@ enum CameraControllerError: Swift.Error {
     case invalidOperation
     case noCamerasAvailable
     case cannotFindDocumentsDirectory
+    case recordingInProgress
     case fileVideoOutputNotFound
     case unknown
     case invalidZoomLevel(min: CGFloat, max: CGFloat, requested: CGFloat)
@@ -2851,6 +2996,8 @@ extension CameraControllerError: LocalizedError {
             return NSLocalizedString("Unknown", comment: "Unknown")
         case .cannotFindDocumentsDirectory:
             return NSLocalizedString("Cannot find documents directory", comment: "This should never happen")
+        case .recordingInProgress:
+            return NSLocalizedString("Cannot change video stabilization while recording is in progress.", comment: "Recording in progress")
         case .fileVideoOutputNotFound:
             return NSLocalizedString("Video recording is not available. Make sure the camera is properly initialized.", comment: "Video recording not available")
         case .invalidZoomLevel(let min, let max, let requested):

--- a/ios/Sources/CapgoCameraPreviewPlugin/CameraController.swift
+++ b/ios/Sources/CapgoCameraPreviewPlugin/CameraController.swift
@@ -273,10 +273,9 @@ class CameraController: NSObject {
         ]
         if #available(iOS 17.0, *) {
             candidates.append(("previewOptimized", .previewOptimized))
-            candidates.append(("cinematicExtendedEnhanced", .cinematicExtendedEnhanced))
         }
         if #available(iOS 18.0, *) {
-            candidates.append(("lowLatency", .lowLatency))
+            candidates.append(("cinematicExtendedEnhanced", .cinematicExtendedEnhanced))
         }
         return candidates
     }
@@ -308,14 +307,11 @@ class CameraController: NSObject {
             }
             return nil
         case "cinematicExtendedEnhanced":
-            if #available(iOS 17.0, *) {
+            if #available(iOS 18.0, *) {
                 return .cinematicExtendedEnhanced
             }
             return nil
         case "lowLatency":
-            if #available(iOS 18.0, *) {
-                return .lowLatency
-            }
             return nil
         default:
             return nil
@@ -339,13 +335,10 @@ class CameraController: NSObject {
                 if mode == .previewOptimized {
                     return "previewOptimized"
                 }
-                if mode == .cinematicExtendedEnhanced {
-                    return "cinematicExtendedEnhanced"
-                }
             }
             if #available(iOS 18.0, *) {
-                if mode == .lowLatency {
-                    return "lowLatency"
+                if mode == .cinematicExtendedEnhanced {
+                    return "cinematicExtendedEnhanced"
                 }
             }
             return self.videoStabilizationMode

--- a/ios/Sources/CapgoCameraPreviewPlugin/Plugin.swift
+++ b/ios/Sources/CapgoCameraPreviewPlugin/Plugin.swift
@@ -1678,6 +1678,14 @@ public class CameraPreview: CAPPlugin, CAPBridgedPlugin, CLLocationManagerDelega
         if let videoCodec = call.getString("videoCodec") {
             try? self.cameraController.setVideoCodec(videoCodec)
         }
+        if let videoStabilizationMode = call.getString("videoStabilizationMode") {
+            do {
+                try self.cameraController.setVideoStabilizationMode(videoStabilizationMode)
+            } catch {
+                call.reject("Failed to set video stabilization mode: \(error.localizedDescription)")
+                return
+            }
+        }
         self.cameraController.recordingFinishedCallback = { [weak self] fileURL, reason in
             DispatchQueue.main.async {
                 self?.notifyListeners("recordingFinished", data: ["videoFilePath": fileURL.absoluteString, "reason": reason])

--- a/ios/Sources/CapgoCameraPreviewPlugin/Plugin.swift
+++ b/ios/Sources/CapgoCameraPreviewPlugin/Plugin.swift
@@ -54,6 +54,10 @@ public class CameraPreview: CAPPlugin, CAPBridgedPlugin, CLLocationManagerDelega
         CAPPluginMethod(name: "getSupportedVideoCodecs", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "getVideoCodec", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "setVideoCodec", returnType: CAPPluginReturnPromise),
+        CAPPluginMethod(name: "isVideoStabilizationSupported", returnType: CAPPluginReturnPromise),
+        CAPPluginMethod(name: "getSupportedVideoStabilizationModes", returnType: CAPPluginReturnPromise),
+        CAPPluginMethod(name: "getVideoStabilizationMode", returnType: CAPPluginReturnPromise),
+        CAPPluginMethod(name: "setVideoStabilizationMode", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "getSupportedVideoQualities", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "getVideoQuality", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "setVideoQuality", returnType: CAPPluginReturnPromise),
@@ -1641,6 +1645,31 @@ public class CameraPreview: CAPPlugin, CAPBridgedPlugin, CLLocationManagerDelega
 
     @objc func getSupportedVideoCodecs(_ call: CAPPluginCall) {
         call.resolve(["codecs": self.cameraController.getSupportedVideoCodecs()])
+    }
+
+    @objc func isVideoStabilizationSupported(_ call: CAPPluginCall) {
+        call.resolve(["supported": self.cameraController.isVideoStabilizationSupported()])
+    }
+
+    @objc func getSupportedVideoStabilizationModes(_ call: CAPPluginCall) {
+        call.resolve(["modes": self.cameraController.getSupportedVideoStabilizationModes()])
+    }
+
+    @objc func getVideoStabilizationMode(_ call: CAPPluginCall) {
+        call.resolve(["mode": self.cameraController.getVideoStabilizationMode()])
+    }
+
+    @objc func setVideoStabilizationMode(_ call: CAPPluginCall) {
+        guard let mode = call.getString("mode") else {
+            call.reject("mode is required")
+            return
+        }
+        do {
+            try self.cameraController.setVideoStabilizationMode(mode)
+            call.resolve()
+        } catch {
+            call.reject("Failed to set video stabilization mode: \(error.localizedDescription)")
+        }
     }
 
     @objc func startRecordVideo(_ call: CAPPluginCall) {

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -147,6 +147,22 @@ export type VideoQuality = 'low' | 'medium' | 'high' | '2160p' | '1080p' | '720p
  */
 export type VideoCodec = 'avc1' | 'hvc1' | 'jpeg' | 'apcn' | 'ap4h';
 
+/**
+ * Video stabilization modes used when recording.
+ *
+ * On Android only `off` and `standard` are supported.
+ * On iOS all listed modes may be available when the device supports video stabilization.
+ */
+export type VideoStabilizationMode =
+  | 'off'
+  | 'standard'
+  | 'cinematic'
+  | 'cinematicExtended'
+  | 'previewOptimized'
+  | 'cinematicExtendedEnhanced'
+  | 'auto'
+  | 'lowLatency';
+
 export type RecordingFinishedReason = 'manual' | 'maxDuration' | 'maxFileSize';
 
 export interface RecordingFinishedEvent {
@@ -767,6 +783,44 @@ export interface CameraPreviewPlugin {
    * @platform android, ios
    */
   getSupportedVideoCodecs(): Promise<{ codecs: VideoCodec[] }>;
+
+  /**
+   * Checks whether video stabilization is supported by the active camera.
+   *
+   * @returns {Promise<{ supported: boolean }>} A promise that resolves with the support state.
+   * @since 8.5.2
+   * @platform android, ios
+   */
+  isVideoStabilizationSupported(): Promise<{ supported: boolean }>;
+
+  /**
+   * Returns the video stabilization modes supported by the active camera.
+   *
+   * @returns {Promise<{ modes: VideoStabilizationMode[] }>} A promise that resolves with supported modes.
+   * @since 8.5.2
+   * @platform android, ios
+   */
+  getSupportedVideoStabilizationModes(): Promise<{ modes: VideoStabilizationMode[] }>;
+
+  /**
+   * Gets the current video stabilization mode.
+   *
+   * @returns {Promise<{ mode: VideoStabilizationMode }>} A promise that resolves with the current mode.
+   * @since 8.5.2
+   * @platform android, ios
+   */
+  getVideoStabilizationMode(): Promise<{ mode: VideoStabilizationMode }>;
+
+  /**
+   * Sets the video stabilization mode for recording.
+   * Cannot be changed while a recording is in progress.
+   *
+   * @param {{ mode: VideoStabilizationMode }} options - The desired stabilization mode.
+   * @returns {Promise<void>} A promise that resolves when the mode is set.
+   * @since 8.5.2
+   * @platform android, ios
+   */
+  setVideoStabilizationMode(options: { mode: VideoStabilizationMode }): Promise<void>;
 
   /**
    * Checks if the camera preview is currently running.

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -363,6 +363,12 @@ export interface CameraPreviewOptions {
    */
   videoCodec?: VideoCodec;
   /**
+   * Preferred video stabilization mode for recording.
+   * @platform ios, android
+   * @default "off"
+   */
+  videoStabilizationMode?: VideoStabilizationMode;
+  /**
    * Starts barcode scanning together with the camera preview.
    * Set to `true` or pass options to scan all supported formats.
    * Omit this option to keep barcode scanning disabled at startup.
@@ -722,7 +728,7 @@ export interface CameraPreviewPlugin {
   /**
    * Starts recording a video.
    *
-   * @param {CameraPreviewOptions} options - The options for video recording.
+   * @param {CameraPreviewOptions} options - The options for video recording. Supports `videoCodec`, `videoStabilizationMode`, `maxDuration`, `maxFileSize`, and `disableAudio`.
    * @returns {Promise<void>} A promise that resolves when video recording starts.
    * @since 0.0.1
    */
@@ -814,6 +820,7 @@ export interface CameraPreviewPlugin {
   /**
    * Sets the video stabilization mode for recording.
    * Cannot be changed while a recording is in progress.
+   * You can also pass `videoStabilizationMode` in `startRecordVideo()` options.
    *
    * @param {{ mode: VideoStabilizationMode }} options - The desired stabilization mode.
    * @returns {Promise<void>} A promise that resolves when the mode is set.

--- a/src/web.ts
+++ b/src/web.ts
@@ -23,6 +23,7 @@ import type {
   PermissionRequestOptions,
   SafeAreaInsets,
   VideoCodec,
+  VideoStabilizationMode,
   VideoQuality,
 } from './definitions';
 import { DeviceType } from './definitions';
@@ -989,6 +990,22 @@ export class CameraPreviewWeb extends WebPlugin implements CameraPreviewPlugin {
 
   async getSupportedVideoCodecs(): Promise<{ codecs: VideoCodec[] }> {
     throw this.unimplemented('getSupportedVideoCodecs');
+  }
+
+  async isVideoStabilizationSupported(): Promise<{ supported: boolean }> {
+    throw this.unimplemented('isVideoStabilizationSupported');
+  }
+
+  async getSupportedVideoStabilizationModes(): Promise<{ modes: VideoStabilizationMode[] }> {
+    throw this.unimplemented('getSupportedVideoStabilizationModes');
+  }
+
+  async getVideoStabilizationMode(): Promise<{ mode: VideoStabilizationMode }> {
+    throw this.unimplemented('getVideoStabilizationMode');
+  }
+
+  async setVideoStabilizationMode(): Promise<void> {
+    throw this.unimplemented('setVideoStabilizationMode');
   }
 
   async isRunning(): Promise<{ isRunning: boolean }> {


### PR DESCRIPTION
## Summary
- Adds `isVideoStabilizationSupported`, `getSupportedVideoStabilizationModes`, `getVideoStabilizationMode`, and `setVideoStabilizationMode` to the plugin API
- iOS uses `AVCaptureConnection` stabilization APIs and probes connection-supported modes before recording
- Android maps stabilization to CameraX `VideoCapture.Builder.setVideoStabilizationEnabled` and only exposes `off` / `standard`

## Test plan
- [x] `bun run verify:android`
- [x] `bun run verify:web`
- [ ] `bun run verify:ios` (requires local Xcode iOS platform)
- [ ] On iOS device/simulator: call `getSupportedVideoStabilizationModes()` and set a supported mode before `startRecordVideo()`
- [ ] On Android device: verify only `off`/`standard` are returned and `standard` enables stabilization when supported
- [ ] Verify `setVideoStabilizationMode` is rejected while recording is in progress

Closes #370

Made with [Cursor](https://cursor.com)