### PR TITLE
feat: white-balance mode control (fixes iOS yellow/warm tint)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1374,7 +1374,8 @@ getWhiteBalanceModes() => Promise<{ modes: WhiteBalanceMode[]; }>
 ```
 
 Returns the white-balance modes supported by the active camera.
-Modes can include: 'AUTO', 'LOCK', 'CONTINUOUS'.
+Modes can include: 'AUTO', 'LOCK', 'CONTINUOUS'. `CUSTOM` is not listed
+until manual gains support is implemented.
 
 **Returns:** <code>Promise&lt;{ modes: WhiteBalanceMode[]; }&gt;</code>
 
@@ -1402,7 +1403,8 @@ setWhiteBalanceMode(options: { mode: WhiteBalanceMode; }) => Promise<void>
 
 Sets the white-balance mode. `CONTINUOUS` keeps auto white balance running
 (recommended; avoids a warm/yellow cast), `LOCK` freezes the current gains,
-`AUTO` performs a one-time adjustment.
+`AUTO` performs a one-time adjustment. `CUSTOM` is reserved and rejected
+until manual gains support is implemented.
 
 | Param         | Type                                                                     |
 | ------------- | ------------------------------------------------------------------------ |
@@ -1808,8 +1810,10 @@ Reusable exposure mode type for cross-platform support.
 #### WhiteBalanceMode
 
 Reusable white-balance mode type for cross-platform support.
+`CUSTOM` is reserved for a future manual white-balance gains API and is not
+returned by `getWhiteBalanceModes()` until implemented.
 
-<code>'AUTO' | 'LOCK' | 'CONTINUOUS'</code>
+<code>'AUTO' | 'LOCK' | 'CONTINUOUS' | 'CUSTOM'</code>
 
 
 ### Enums

--- a/README.md
+++ b/README.md
@@ -412,6 +412,9 @@ Documentation for the [uploader](https://github.com/Cap-go/capacitor-uploader)
 * [`getExposureCompensationRange()`](#getexposurecompensationrange)
 * [`getExposureCompensation()`](#getexposurecompensation)
 * [`setExposureCompensation(...)`](#setexposurecompensation)
+* [`getWhiteBalanceModes()`](#getwhitebalancemodes)
+* [`getWhiteBalanceMode()`](#getwhitebalancemode)
+* [`setWhiteBalanceMode(...)`](#setwhitebalancemode)
 * [`getSupportedVideoFrameRates()`](#getsupportedvideoframerates)
 * [`getVideoFrameRate()`](#getvideoframerate)
 * [`setVideoFrameRate(...)`](#setvideoframerate)
@@ -1364,6 +1367,50 @@ Sets the exposure compensation (EV bias). Value will be clamped to range.
 --------------------
 
 
+### getWhiteBalanceModes()
+
+```typescript
+getWhiteBalanceModes() => Promise<{ modes: WhiteBalanceMode[]; }>
+```
+
+Returns the white-balance modes supported by the active camera.
+Modes can include: 'AUTO', 'LOCK', 'CONTINUOUS'.
+
+**Returns:** <code>Promise&lt;{ modes: WhiteBalanceMode[]; }&gt;</code>
+
+--------------------
+
+
+### getWhiteBalanceMode()
+
+```typescript
+getWhiteBalanceMode() => Promise<{ mode: WhiteBalanceMode; }>
+```
+
+Returns the current white-balance mode.
+
+**Returns:** <code>Promise&lt;{ mode: <a href="#whitebalancemode">WhiteBalanceMode</a>; }&gt;</code>
+
+--------------------
+
+
+### setWhiteBalanceMode(...)
+
+```typescript
+setWhiteBalanceMode(options: { mode: WhiteBalanceMode; }) => Promise<void>
+```
+
+Sets the white-balance mode. `CONTINUOUS` keeps auto white balance running
+(recommended; avoids a warm/yellow cast), `LOCK` freezes the current gains,
+`AUTO` performs a one-time adjustment.
+
+| Param         | Type                                                                     |
+| ------------- | ------------------------------------------------------------------------ |
+| **`options`** | <code>{ mode: <a href="#whitebalancemode">WhiteBalanceMode</a>; }</code> |
+
+--------------------
+
+
 ### getSupportedVideoFrameRates()
 
 ```typescript
@@ -1756,6 +1803,13 @@ Canonical device orientation values across platforms.
 Reusable exposure mode type for cross-platform support.
 
 <code>'AUTO' | 'LOCK' | 'CONTINUOUS' | 'CUSTOM'</code>
+
+
+#### WhiteBalanceMode
+
+Reusable white-balance mode type for cross-platform support.
+
+<code>'AUTO' | 'LOCK' | 'CONTINUOUS'</code>
 
 
 ### Enums

--- a/android/src/main/java/app/capgo/capacitor/camera/preview/CameraPreview.java
+++ b/android/src/main/java/app/capgo/capacitor/camera/preview/CameraPreview.java
@@ -196,6 +196,49 @@ public class CameraPreview extends Plugin implements CameraXView.CameraXViewList
     }
 
     @PluginMethod
+    public void getWhiteBalanceModes(PluginCall call) {
+        if (cameraXView == null || !cameraXView.isRunning()) {
+            call.reject("Camera is not running");
+            return;
+        }
+        JSArray arr = new JSArray();
+        for (String m : cameraXView.getWhiteBalanceModes()) arr.put(m);
+        JSObject ret = new JSObject();
+        ret.put("modes", arr);
+        call.resolve(ret);
+    }
+
+    @PluginMethod
+    public void getWhiteBalanceMode(PluginCall call) {
+        if (cameraXView == null || !cameraXView.isRunning()) {
+            call.reject("Camera is not running");
+            return;
+        }
+        JSObject ret = new JSObject();
+        ret.put("mode", cameraXView.getWhiteBalanceMode());
+        call.resolve(ret);
+    }
+
+    @PluginMethod
+    public void setWhiteBalanceMode(PluginCall call) {
+        if (cameraXView == null || !cameraXView.isRunning()) {
+            call.reject("Camera is not running");
+            return;
+        }
+        String mode = call.getString("mode");
+        if (mode == null || mode.isEmpty()) {
+            call.reject("mode parameter is required");
+            return;
+        }
+        try {
+            cameraXView.setWhiteBalanceMode(mode);
+            call.resolve();
+        } catch (Exception e) {
+            call.reject("Failed to set white balance mode: " + e.getMessage());
+        }
+    }
+
+    @PluginMethod
     public void getExposureModes(PluginCall call) {
         if (cameraXView == null || !cameraXView.isRunning()) {
             call.reject("Camera is not running");

--- a/android/src/main/java/app/capgo/capacitor/camera/preview/CameraXView.java
+++ b/android/src/main/java/app/capgo/capacitor/camera/preview/CameraXView.java
@@ -3373,11 +3373,7 @@ public class CameraXView implements LifecycleOwner, LifecycleObserver {
         if ("CUSTOM".equals(normalized)) {
             throw new Exception("CUSTOM white balance is not supported; manual gains are not yet exposed");
         }
-        if (
-            !"LOCK".equals(normalized) &&
-            !"AUTO".equals(normalized) &&
-            !"CONTINUOUS".equals(normalized)
-        ) {
+        if (!"LOCK".equals(normalized) && !"AUTO".equals(normalized) && !"CONTINUOUS".equals(normalized)) {
             throw new Exception("Unsupported white balance mode: " + mode);
         }
         final String modeToApply = normalized;

--- a/android/src/main/java/app/capgo/capacitor/camera/preview/CameraXView.java
+++ b/android/src/main/java/app/capgo/capacitor/camera/preview/CameraXView.java
@@ -1184,6 +1184,7 @@ public class CameraXView implements LifecycleOwner, LifecycleObserver {
                 }
 
                 resetExposureCompensationToDefault();
+                reapplyCameraControlModes();
 
                 // Log details about the active camera
                 Log.d(TAG, "Use cases bound. Inspecting active camera and use cases.");
@@ -3279,13 +3280,26 @@ public class CameraXView implements LifecycleOwner, LifecycleObserver {
 
     @OptIn(markerClass = ExperimentalCamera2Interop.class)
     public void setExposureMode(String mode) throws Exception {
-        if (camera == null) {
-            throw new Exception("Camera not initialized");
-        }
         if (mode == null) {
             throw new Exception("mode is required");
         }
         String normalized = mode.toUpperCase(Locale.US);
+        final String modeToApply = normalized;
+        mainExecutor.execute(() -> {
+            try {
+                applyExposureMode(modeToApply);
+            } catch (Exception e) {
+                Log.e(TAG, "setExposureMode: Failed to apply mode", e);
+            }
+        });
+        currentExposureMode = normalized;
+    }
+
+    @OptIn(markerClass = ExperimentalCamera2Interop.class)
+    private void applyExposureMode(String normalized) throws Exception {
+        if (camera == null) {
+            throw new Exception("Camera not initialized");
+        }
 
         Camera2CameraControl c2 = Camera2CameraControl.from(camera.getCameraControl());
         switch (normalized) {
@@ -3294,8 +3308,7 @@ public class CameraXView implements LifecycleOwner, LifecycleObserver {
                     .setCaptureRequestOption(CaptureRequest.CONTROL_AE_LOCK, true)
                     .setCaptureRequestOption(CaptureRequest.CONTROL_AE_MODE, CaptureRequest.CONTROL_AE_MODE_ON)
                     .build();
-                mainExecutor.execute(() -> c2.setCaptureRequestOptions(opts));
-                currentExposureMode = "LOCK";
+                c2.setCaptureRequestOptions(opts);
                 break;
             }
             case "CONTINUOUS": {
@@ -3303,20 +3316,45 @@ public class CameraXView implements LifecycleOwner, LifecycleObserver {
                     .setCaptureRequestOption(CaptureRequest.CONTROL_AE_LOCK, false)
                     .setCaptureRequestOption(CaptureRequest.CONTROL_AE_MODE, CaptureRequest.CONTROL_AE_MODE_ON)
                     .build();
-                mainExecutor.execute(() -> c2.setCaptureRequestOptions(opts));
-                currentExposureMode = "CONTINUOUS";
+                c2.setCaptureRequestOptions(opts);
                 break;
             }
             default:
-                throw new Exception("Unsupported exposure mode: " + mode);
+                throw new Exception("Unsupported exposure mode: " + normalized);
         }
     }
 
     // ===================== White Balance APIs =====================
     public java.util.List<String> getWhiteBalanceModes() {
-        // Camera2 maps AUTO and CONTINUOUS to the same CONTROL_AWB_MODE_AUTO, so only
-        // advertise the modes with distinct behavior (matches getExposureModes()).
-        return Arrays.asList("LOCK", "CONTINUOUS");
+        if (camera == null) {
+            return Arrays.asList("LOCK", "CONTINUOUS");
+        }
+
+        java.util.List<String> modes = new java.util.ArrayList<>();
+        try {
+            Camera2CameraInfo c2Info = Camera2CameraInfo.from(camera.getCameraInfo());
+            int[] available = c2Info.getCameraCharacteristic(CameraCharacteristics.CONTROL_AWB_AVAILABLE_MODES);
+            Boolean lockAvailable = c2Info.getCameraCharacteristic(CameraCharacteristics.CONTROL_AWB_LOCK_AVAILABLE);
+
+            if (available != null) {
+                for (int awbMode : available) {
+                    if (awbMode == CaptureRequest.CONTROL_AWB_MODE_AUTO && !modes.contains("CONTINUOUS")) {
+                        modes.add("CONTINUOUS");
+                    }
+                }
+            }
+            if (Boolean.TRUE.equals(lockAvailable) && !modes.contains("LOCK")) {
+                modes.add("LOCK");
+            }
+        } catch (Exception e) {
+            Log.w(TAG, "getWhiteBalanceModes: Failed to query capabilities, using defaults", e);
+            return Arrays.asList("LOCK", "CONTINUOUS");
+        }
+
+        if (modes.isEmpty()) {
+            return Arrays.asList("LOCK", "CONTINUOUS");
+        }
+        return modes;
     }
 
     public String getWhiteBalanceMode() {
@@ -3325,13 +3363,29 @@ public class CameraXView implements LifecycleOwner, LifecycleObserver {
 
     @OptIn(markerClass = ExperimentalCamera2Interop.class)
     public void setWhiteBalanceMode(String mode) throws Exception {
-        if (camera == null) {
-            throw new Exception("Camera not initialized");
-        }
         if (mode == null) {
             throw new Exception("mode is required");
         }
         String normalized = mode.toUpperCase(Locale.US);
+        if ("CUSTOM".equals(normalized)) {
+            throw new Exception("CUSTOM white balance is not supported; manual gains are not yet exposed");
+        }
+        final String modeToApply = normalized;
+        mainExecutor.execute(() -> {
+            try {
+                applyWhiteBalanceMode(modeToApply);
+            } catch (Exception e) {
+                Log.e(TAG, "setWhiteBalanceMode: Failed to apply mode", e);
+            }
+        });
+        currentWhiteBalanceMode = normalized;
+    }
+
+    @OptIn(markerClass = ExperimentalCamera2Interop.class)
+    private void applyWhiteBalanceMode(String normalized) throws Exception {
+        if (camera == null) {
+            throw new Exception("Camera not initialized");
+        }
 
         Camera2CameraControl c2 = Camera2CameraControl.from(camera.getCameraControl());
         switch (normalized) {
@@ -3340,8 +3394,7 @@ public class CameraXView implements LifecycleOwner, LifecycleObserver {
                     .setCaptureRequestOption(CaptureRequest.CONTROL_AWB_LOCK, true)
                     .setCaptureRequestOption(CaptureRequest.CONTROL_AWB_MODE, CaptureRequest.CONTROL_AWB_MODE_AUTO)
                     .build();
-                mainExecutor.execute(() -> c2.setCaptureRequestOptions(opts));
-                currentWhiteBalanceMode = "LOCK";
+                c2.setCaptureRequestOptions(opts);
                 break;
             }
             case "AUTO":
@@ -3350,12 +3403,27 @@ public class CameraXView implements LifecycleOwner, LifecycleObserver {
                     .setCaptureRequestOption(CaptureRequest.CONTROL_AWB_LOCK, false)
                     .setCaptureRequestOption(CaptureRequest.CONTROL_AWB_MODE, CaptureRequest.CONTROL_AWB_MODE_AUTO)
                     .build();
-                mainExecutor.execute(() -> c2.setCaptureRequestOptions(opts));
-                currentWhiteBalanceMode = normalized;
+                c2.setCaptureRequestOptions(opts);
                 break;
             }
             default:
-                throw new Exception("Unsupported white balance mode: " + mode);
+                throw new Exception("Unsupported white balance mode: " + normalized);
+        }
+    }
+
+    private void reapplyCameraControlModes() {
+        if (camera == null) {
+            return;
+        }
+        try {
+            applyExposureMode(currentExposureMode);
+        } catch (Exception e) {
+            Log.w(TAG, "reapplyCameraControlModes: Failed to reapply exposure mode", e);
+        }
+        try {
+            applyWhiteBalanceMode(currentWhiteBalanceMode);
+        } catch (Exception e) {
+            Log.w(TAG, "reapplyCameraControlModes: Failed to reapply white balance mode", e);
         }
     }
 

--- a/android/src/main/java/app/capgo/capacitor/camera/preview/CameraXView.java
+++ b/android/src/main/java/app/capgo/capacitor/camera/preview/CameraXView.java
@@ -3284,15 +3284,18 @@ public class CameraXView implements LifecycleOwner, LifecycleObserver {
             throw new Exception("mode is required");
         }
         String normalized = mode.toUpperCase(Locale.US);
+        if (!"LOCK".equals(normalized) && !"CONTINUOUS".equals(normalized)) {
+            throw new Exception("Unsupported exposure mode: " + mode);
+        }
         final String modeToApply = normalized;
         mainExecutor.execute(() -> {
             try {
                 applyExposureMode(modeToApply);
+                currentExposureMode = modeToApply;
             } catch (Exception e) {
                 Log.e(TAG, "setExposureMode: Failed to apply mode", e);
             }
         });
-        currentExposureMode = normalized;
     }
 
     @OptIn(markerClass = ExperimentalCamera2Interop.class)
@@ -3370,15 +3373,22 @@ public class CameraXView implements LifecycleOwner, LifecycleObserver {
         if ("CUSTOM".equals(normalized)) {
             throw new Exception("CUSTOM white balance is not supported; manual gains are not yet exposed");
         }
+        if (
+            !"LOCK".equals(normalized) &&
+            !"AUTO".equals(normalized) &&
+            !"CONTINUOUS".equals(normalized)
+        ) {
+            throw new Exception("Unsupported white balance mode: " + mode);
+        }
         final String modeToApply = normalized;
         mainExecutor.execute(() -> {
             try {
                 applyWhiteBalanceMode(modeToApply);
+                currentWhiteBalanceMode = modeToApply;
             } catch (Exception e) {
                 Log.e(TAG, "setWhiteBalanceMode: Failed to apply mode", e);
             }
         });
-        currentWhiteBalanceMode = normalized;
     }
 
     @OptIn(markerClass = ExperimentalCamera2Interop.class)

--- a/android/src/main/java/app/capgo/capacitor/camera/preview/CameraXView.java
+++ b/android/src/main/java/app/capgo/capacitor/camera/preview/CameraXView.java
@@ -191,6 +191,7 @@ public class CameraXView implements LifecycleOwner, LifecycleObserver {
     private Runnable pendingFrameRateBindSuccess;
     private java.util.function.Consumer<String> pendingFrameRateBindError;
     private String currentExposureMode = "CONTINUOUS"; // Default behavior
+    private String currentWhiteBalanceMode = "CONTINUOUS"; // Default behavior
     // Capture/stop coordination
     private final Object captureLock = new Object();
     private volatile boolean isCapturingPhoto = false;
@@ -3308,6 +3309,51 @@ public class CameraXView implements LifecycleOwner, LifecycleObserver {
             }
             default:
                 throw new Exception("Unsupported exposure mode: " + mode);
+        }
+    }
+
+    // ===================== White Balance APIs =====================
+    public java.util.List<String> getWhiteBalanceModes() {
+        return Arrays.asList("AUTO", "LOCK", "CONTINUOUS");
+    }
+
+    public String getWhiteBalanceMode() {
+        return currentWhiteBalanceMode;
+    }
+
+    @OptIn(markerClass = ExperimentalCamera2Interop.class)
+    public void setWhiteBalanceMode(String mode) throws Exception {
+        if (camera == null) {
+            throw new Exception("Camera not initialized");
+        }
+        if (mode == null) {
+            throw new Exception("mode is required");
+        }
+        String normalized = mode.toUpperCase(Locale.US);
+
+        Camera2CameraControl c2 = Camera2CameraControl.from(camera.getCameraControl());
+        switch (normalized) {
+            case "LOCK": {
+                CaptureRequestOptions opts = new CaptureRequestOptions.Builder()
+                    .setCaptureRequestOption(CaptureRequest.CONTROL_AWB_LOCK, true)
+                    .setCaptureRequestOption(CaptureRequest.CONTROL_AWB_MODE, CaptureRequest.CONTROL_AWB_MODE_AUTO)
+                    .build();
+                mainExecutor.execute(() -> c2.setCaptureRequestOptions(opts));
+                currentWhiteBalanceMode = "LOCK";
+                break;
+            }
+            case "AUTO":
+            case "CONTINUOUS": {
+                CaptureRequestOptions opts = new CaptureRequestOptions.Builder()
+                    .setCaptureRequestOption(CaptureRequest.CONTROL_AWB_LOCK, false)
+                    .setCaptureRequestOption(CaptureRequest.CONTROL_AWB_MODE, CaptureRequest.CONTROL_AWB_MODE_AUTO)
+                    .build();
+                mainExecutor.execute(() -> c2.setCaptureRequestOptions(opts));
+                currentWhiteBalanceMode = normalized;
+                break;
+            }
+            default:
+                throw new Exception("Unsupported white balance mode: " + mode);
         }
     }
 

--- a/android/src/main/java/app/capgo/capacitor/camera/preview/CameraXView.java
+++ b/android/src/main/java/app/capgo/capacitor/camera/preview/CameraXView.java
@@ -3314,7 +3314,9 @@ public class CameraXView implements LifecycleOwner, LifecycleObserver {
 
     // ===================== White Balance APIs =====================
     public java.util.List<String> getWhiteBalanceModes() {
-        return Arrays.asList("AUTO", "LOCK", "CONTINUOUS");
+        // Camera2 maps AUTO and CONTINUOUS to the same CONTROL_AWB_MODE_AUTO, so only
+        // advertise the modes with distinct behavior (matches getExposureModes()).
+        return Arrays.asList("LOCK", "CONTINUOUS");
     }
 
     public String getWhiteBalanceMode() {

--- a/ios/Sources/CapgoCameraPreviewPlugin/CameraController.swift
+++ b/ios/Sources/CapgoCameraPreviewPlugin/CameraController.swift
@@ -2663,8 +2663,10 @@ extension CameraController {
             desiredMode = .autoWhiteBalance
         case "CONTINUOUS":
             desiredMode = .continuousAutoWhiteBalance
+        case "CUSTOM":
+            throw CameraControllerError.invalidOperation
         default:
-            desiredMode = .continuousAutoWhiteBalance
+            throw CameraControllerError.invalidOperation
         }
 
         guard let finalMode = desiredMode, device.isWhiteBalanceModeSupported(finalMode) else {

--- a/ios/Sources/CapgoCameraPreviewPlugin/CameraController.swift
+++ b/ios/Sources/CapgoCameraPreviewPlugin/CameraController.swift
@@ -926,6 +926,10 @@ extension CameraController {
                     finalDevice.exposurePointOfInterest = CGPoint(x: 0.5, y: 0.5)
                 }
             }
+            // Default white balance to continuous auto (prevents a warm/yellow cast)
+            if finalDevice.isWhiteBalanceModeSupported(.continuousAutoWhiteBalance) {
+                finalDevice.whiteBalanceMode = .continuousAutoWhiteBalance
+            }
             // Reset exposure compensation so sessions start neutral
             let minBias = finalDevice.minExposureTargetBias
             let maxBias = finalDevice.maxExposureTargetBias
@@ -2578,6 +2582,98 @@ extension CameraController {
         do {
             try device.lockForConfiguration()
             device.setExposureTargetBias(clamped) { _ in }
+            device.unlockForConfiguration()
+        } catch {
+            throw CameraControllerError.invalidOperation
+        }
+    }
+
+    // MARK: - White Balance Controls
+
+    func getWhiteBalanceModes() throws -> [String] {
+        var currentCamera: AVCaptureDevice?
+        switch currentCameraPosition {
+        case .front:
+            currentCamera = self.frontCamera
+        case .rear:
+            currentCamera = self.rearCamera
+        default:
+            break
+        }
+
+        guard let device = currentCamera else {
+            throw CameraControllerError.noCamerasAvailable
+        }
+
+        var modes: [String] = []
+        if device.isWhiteBalanceModeSupported(.locked) { modes.append("LOCK") }
+        if device.isWhiteBalanceModeSupported(.autoWhiteBalance) { modes.append("AUTO") }
+        if device.isWhiteBalanceModeSupported(.continuousAutoWhiteBalance) { modes.append("CONTINUOUS") }
+        return modes
+    }
+
+    func getWhiteBalanceMode() throws -> String {
+        var currentCamera: AVCaptureDevice?
+        switch currentCameraPosition {
+        case .front:
+            currentCamera = self.frontCamera
+        case .rear:
+            currentCamera = self.rearCamera
+        default:
+            break
+        }
+
+        guard let device = currentCamera else {
+            throw CameraControllerError.noCamerasAvailable
+        }
+
+        switch device.whiteBalanceMode {
+        case .locked:
+            return "LOCK"
+        case .autoWhiteBalance:
+            return "AUTO"
+        case .continuousAutoWhiteBalance:
+            return "CONTINUOUS"
+        @unknown default:
+            return "CONTINUOUS"
+        }
+    }
+
+    func setWhiteBalanceMode(mode: String) throws {
+        var currentCamera: AVCaptureDevice?
+        switch currentCameraPosition {
+        case .front:
+            currentCamera = self.frontCamera
+        case .rear:
+            currentCamera = self.rearCamera
+        default:
+            break
+        }
+
+        guard let device = currentCamera else {
+            throw CameraControllerError.noCamerasAvailable
+        }
+
+        let normalized = mode.uppercased()
+        let desiredMode: AVCaptureDevice.WhiteBalanceMode?
+        switch normalized {
+        case "LOCK":
+            desiredMode = .locked
+        case "AUTO":
+            desiredMode = .autoWhiteBalance
+        case "CONTINUOUS":
+            desiredMode = .continuousAutoWhiteBalance
+        default:
+            desiredMode = .continuousAutoWhiteBalance
+        }
+
+        guard let finalMode = desiredMode, device.isWhiteBalanceModeSupported(finalMode) else {
+            throw CameraControllerError.invalidOperation
+        }
+
+        do {
+            try device.lockForConfiguration()
+            device.whiteBalanceMode = finalMode
             device.unlockForConfiguration()
         } catch {
             throw CameraControllerError.invalidOperation

--- a/ios/Sources/CapgoCameraPreviewPlugin/Plugin.swift
+++ b/ios/Sources/CapgoCameraPreviewPlugin/Plugin.swift
@@ -90,6 +90,9 @@ public class CameraPreview: CAPPlugin, CAPBridgedPlugin, CLLocationManagerDelega
         CAPPluginMethod(name: "getExposureCompensationRange", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "getExposureCompensation", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "setExposureCompensation", returnType: CAPPluginReturnPromise),
+        CAPPluginMethod(name: "getWhiteBalanceModes", returnType: CAPPluginReturnPromise),
+        CAPPluginMethod(name: "getWhiteBalanceMode", returnType: CAPPluginReturnPromise),
+        CAPPluginMethod(name: "setWhiteBalanceMode", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "getSupportedVideoFrameRates", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "getVideoFrameRate", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "setVideoFrameRate", returnType: CAPPluginReturnPromise),
@@ -2369,6 +2372,58 @@ public class CameraPreview: CAPPlugin, CAPBridgedPlugin, CLLocationManagerDelega
             } catch {
                 call.reject("Failed to set focus: \(error.localizedDescription)")
             }
+        }
+    }
+
+    // MARK: - White Balance Bridge
+
+    @objc func getWhiteBalanceModes(_ call: CAPPluginCall) {
+        guard isInitialized else {
+            call.reject("Camera not initialized")
+            return
+        }
+        do {
+            let modes = try self.cameraController.getWhiteBalanceModes()
+            call.resolve(["modes": modes])
+        } catch {
+            call.reject("Failed to get white balance modes: \(error.localizedDescription)")
+        }
+    }
+
+    @objc func getWhiteBalanceMode(_ call: CAPPluginCall) {
+        guard isInitialized else {
+            call.reject("Camera not initialized")
+            return
+        }
+        do {
+            let mode = try self.cameraController.getWhiteBalanceMode()
+            call.resolve(["mode": mode])
+        } catch {
+            call.reject("Failed to get white balance mode: \(error.localizedDescription)")
+        }
+    }
+
+    @objc func setWhiteBalanceMode(_ call: CAPPluginCall) {
+        guard isInitialized else {
+            call.reject("Camera not initialized")
+            return
+        }
+        guard let mode = call.getString("mode") else {
+            call.reject("mode parameter is required")
+            return
+        }
+        let normalized = mode.uppercased()
+        let allowedModes: Set<String> = ["AUTO", "LOCK", "CONTINUOUS"]
+        guard allowedModes.contains(normalized) else {
+            let allowedList = Array(allowedModes).sorted().joined(separator: ", ")
+            call.reject("Invalid white balance mode: \(mode). Allowed values: \(allowedList)")
+            return
+        }
+        do {
+            try self.cameraController.setWhiteBalanceMode(mode: normalized)
+            call.resolve()
+        } catch {
+            call.reject("Failed to set white balance mode: \(error.localizedDescription)")
         }
     }
 

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -493,6 +493,9 @@ export type CameraPreviewFlashMode = 'off' | 'on' | 'auto' | 'torch';
 /** Reusable exposure mode type for cross-platform support. */
 export type ExposureMode = 'AUTO' | 'LOCK' | 'CONTINUOUS' | 'CUSTOM';
 
+/** Reusable white-balance mode type for cross-platform support. */
+export type WhiteBalanceMode = 'AUTO' | 'LOCK' | 'CONTINUOUS';
+
 /**
  * Defines the options for setting the camera preview's opacity.
  */
@@ -1095,6 +1098,27 @@ export interface CameraPreviewPlugin {
    * @platform ios, android
    */
   setExposureCompensation(options: { value: number }): Promise<void>;
+
+  /**
+   * Returns the white-balance modes supported by the active camera.
+   * Modes can include: 'AUTO', 'LOCK', 'CONTINUOUS'.
+   * @platform android, ios
+   */
+  getWhiteBalanceModes(): Promise<{ modes: WhiteBalanceMode[] }>;
+
+  /**
+   * Returns the current white-balance mode.
+   * @platform android, ios
+   */
+  getWhiteBalanceMode(): Promise<{ mode: WhiteBalanceMode }>;
+
+  /**
+   * Sets the white-balance mode. `CONTINUOUS` keeps auto white balance running
+   * (recommended; avoids a warm/yellow cast), `LOCK` freezes the current gains,
+   * `AUTO` performs a one-time adjustment.
+   * @platform android, ios
+   */
+  setWhiteBalanceMode(options: { mode: WhiteBalanceMode }): Promise<void>;
 
   /**
    * Lists the video frame rates supported by the active camera for the current format.

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -493,8 +493,12 @@ export type CameraPreviewFlashMode = 'off' | 'on' | 'auto' | 'torch';
 /** Reusable exposure mode type for cross-platform support. */
 export type ExposureMode = 'AUTO' | 'LOCK' | 'CONTINUOUS' | 'CUSTOM';
 
-/** Reusable white-balance mode type for cross-platform support. */
-export type WhiteBalanceMode = 'AUTO' | 'LOCK' | 'CONTINUOUS';
+/**
+ * Reusable white-balance mode type for cross-platform support.
+ * `CUSTOM` is reserved for a future manual white-balance gains API and is not
+ * returned by `getWhiteBalanceModes()` until implemented.
+ */
+export type WhiteBalanceMode = 'AUTO' | 'LOCK' | 'CONTINUOUS' | 'CUSTOM';
 
 /**
  * Defines the options for setting the camera preview's opacity.
@@ -1101,7 +1105,8 @@ export interface CameraPreviewPlugin {
 
   /**
    * Returns the white-balance modes supported by the active camera.
-   * Modes can include: 'AUTO', 'LOCK', 'CONTINUOUS'.
+   * Modes can include: 'AUTO', 'LOCK', 'CONTINUOUS'. `CUSTOM` is not listed
+   * until manual gains support is implemented.
    * @platform android, ios
    */
   getWhiteBalanceModes(): Promise<{ modes: WhiteBalanceMode[] }>;
@@ -1115,7 +1120,8 @@ export interface CameraPreviewPlugin {
   /**
    * Sets the white-balance mode. `CONTINUOUS` keeps auto white balance running
    * (recommended; avoids a warm/yellow cast), `LOCK` freezes the current gains,
-   * `AUTO` performs a one-time adjustment.
+   * `AUTO` performs a one-time adjustment. `CUSTOM` is reserved and rejected
+   * until manual gains support is implemented.
    * @platform android, ios
    */
   setWhiteBalanceMode(options: { mode: WhiteBalanceMode }): Promise<void>;

--- a/src/web.ts
+++ b/src/web.ts
@@ -18,6 +18,7 @@ import type {
   DeviceOrientation,
   GridMode,
   ExposureMode,
+  WhiteBalanceMode,
   FlashMode,
   LensInfo,
   PermissionRequestOptions,
@@ -1561,6 +1562,20 @@ export class CameraPreviewWeb extends WebPlugin implements CameraPreviewPlugin {
   async setExposureCompensation(_options: { value: number }): Promise<void> {
     void _options; // Mark as intentionally unused
     throw new Error('setExposureCompensation not supported under the web platform');
+  }
+
+  // White balance stubs (unsupported on web)
+  async getWhiteBalanceModes(): Promise<{ modes: WhiteBalanceMode[] }> {
+    throw new Error('getWhiteBalanceModes not supported under the web platform');
+  }
+
+  async getWhiteBalanceMode(): Promise<{ mode: WhiteBalanceMode }> {
+    throw new Error('getWhiteBalanceMode not supported under the web platform');
+  }
+
+  async setWhiteBalanceMode(_options: { mode: WhiteBalanceMode }): Promise<void> {
+    void _options; // Mark as intentionally unused
+    throw new Error('setWhiteBalanceMode not supported under the web platform');
   }
 
   async getSupportedVideoFrameRates(): Promise<{ frameRates: number[] }> {


### PR DESCRIPTION
Adds white-balance mode control, mirroring the existing exposure-mode controls. Resolves #374.

### Why
On iOS, captured photos can have a warm/yellow cast and there's no way to influence white balance (the plugin exposes flash + exposure only). This adds a WB API and, more importantly, **defaults the device to `.continuousAutoWhiteBalance` on start**, which fixes the cast for the common case.

### API (mirrors exposure)
```ts
type WhiteBalanceMode = 'AUTO' | 'LOCK' | 'CONTINUOUS';
getWhiteBalanceModes(): Promise<{ modes: WhiteBalanceMode[] }>;
getWhiteBalanceMode(): Promise<{ mode: WhiteBalanceMode }>;
setWhiteBalanceMode(options: { mode: WhiteBalanceMode }): Promise<void>;
```

### Changes
- **TS** (`src/definitions.ts`): `WhiteBalanceMode` type + 3 methods. **Web** (`src/web.ts`): unsupported-platform stubs.
- **iOS**: `CameraController.swift` get/get/set via `AVCaptureDevice.whiteBalanceMode` (`.locked` / `.autoWhiteBalance` / `.continuousAutoWhiteBalance`, guarded by `isWhiteBalanceModeSupported`); `Plugin.swift` registrations + bridge; **continuous-auto-WB default on camera start** (next to the existing continuous-exposure default).
- **Android**: `CameraXView.java` get/get/set via Camera2 `CONTROL_AWB_MODE` / `CONTROL_AWB_LOCK` (`Camera2CameraControl`); `CameraPreview.java` `@PluginMethod` bridge.
- **README** regenerated via `docgen`.

### Validation
- `tsc` compiles clean; `docgen` regenerated the README; `npm run check:wiring` passes (methods consistent across TS/iOS/Android).
- I implemented the native code by mirroring the existing exposure controls but **could not run `verify:ios` / `verify:android`** in my environment — would appreciate a maintainer build/on-device check, and happy to adjust per review.

Thanks for maintaining this plugin!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added white-balance controls to the camera API: list supported modes, get the current mode, and set a new mode.
  * Supported modes include **AUTO**, **LOCK**, and **CONTINUOUS** (with **CUSTOM** reserved and rejected until manual gains are available).
  * Web now exposes stub methods that report the feature as unsupported.

* **Bug Fixes**
  * Improved readiness checks so operations only run when the camera is active, with clearer validation errors.

* **Documentation**
  * Updated API docs and type definitions to include `WhiteBalanceMode` and the new method contracts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->