### PR TITLE
fix(ios): wait for video finalization before resolving stopRecordVideo (fixes #376)

### DIFF
--- a/ios/Sources/CapgoCameraPreviewPlugin/CameraController.swift
+++ b/ios/Sources/CapgoCameraPreviewPlugin/CameraController.swift
@@ -150,6 +150,7 @@ class CameraController: NSObject {
 
     var videoFileURL: URL?
     var recordingFinishedCallback: ((URL, String) -> Void)?
+    private var stopRecordingCompletion: ((URL?, String?, Error?) -> Void)?
     private let saneMaxZoomFactor: CGFloat = 25.5
 
     var videoQuality: String = "high"
@@ -2790,21 +2791,26 @@ extension CameraController {
         self.videoFileURL = fileUrl
     }
 
-    func stopRecording(completion: @escaping (URL?, Error?) -> Void) {
+    func stopRecording(completion: @escaping (URL?, String?, Error?) -> Void) {
         guard let captureSession = self.captureSession, captureSession.isRunning else {
-            completion(nil, CameraControllerError.captureSessionIsMissing)
+            completion(nil, nil, CameraControllerError.captureSessionIsMissing)
             return
         }
         guard let fileVideoOutput = self.fileVideoOutput else {
-            completion(nil, CameraControllerError.fileVideoOutputNotFound)
+            completion(nil, nil, CameraControllerError.fileVideoOutputNotFound)
+            return
+        }
+        guard fileVideoOutput.isRecording else {
+            completion(nil, nil, CameraControllerError.invalidOperation)
+            return
+        }
+        guard self.stopRecordingCompletion == nil else {
+            completion(nil, nil, CameraControllerError.invalidOperation)
             return
         }
 
-        // Stop recording video
+        self.stopRecordingCompletion = completion
         fileVideoOutput.stopRecording()
-
-        // Return the video file URL in the completion handler
-        completion(self.videoFileURL, nil)
     }
 }
 
@@ -3200,6 +3206,19 @@ extension UIImage {
 extension CameraController: AVCaptureFileOutputRecordingDelegate {
     func fileOutput(_ output: AVCaptureFileOutput, didFinishRecordingTo outputFileURL: URL, from connections: [AVCaptureConnection], error: Error?) {
         let reason = recordingFinishReason(from: error)
+        let stopCompletion = self.stopRecordingCompletion
+        self.stopRecordingCompletion = nil
+
+        if let stopCompletion = stopCompletion {
+            DispatchQueue.main.async {
+                if reason == "error" {
+                    stopCompletion(nil, nil, error ?? CameraControllerError.unknown)
+                } else {
+                    stopCompletion(outputFileURL, reason, nil)
+                }
+            }
+        }
+
         if reason == "error" {
             print("Error recording movie: \(error?.localizedDescription ?? "unknown")")
             return

--- a/ios/Sources/CapgoCameraPreviewPlugin/Plugin.swift
+++ b/ios/Sources/CapgoCameraPreviewPlugin/Plugin.swift
@@ -1707,8 +1707,8 @@ public class CameraPreview: CAPPlugin, CAPBridgedPlugin, CLLocationManagerDelega
     }
 
     @objc func stopRecordVideo(_ call: CAPPluginCall) {
-        self.cameraController.stopRecording { (fileURL, error) in
-            guard let fileURL = fileURL else {
+        self.cameraController.stopRecording { (fileURL, reason, error) in
+            guard let fileURL = fileURL, let reason = reason else {
                 print(error ?? "Video capture error")
                 guard let error = error else {
                     call.reject("Video capture error")
@@ -1718,7 +1718,7 @@ public class CameraPreview: CAPPlugin, CAPBridgedPlugin, CLLocationManagerDelega
                 return
             }
 
-            call.resolve(["videoFilePath": fileURL.absoluteString, "reason": "manual"])
+            call.resolve(["videoFilePath": fileURL.absoluteString, "reason": reason])
         }
     }
 


### PR DESCRIPTION
## Summary
- Defer `stopRecordVideo()` resolution on iOS until `AVCaptureFileOutput` calls `fileOutput(_:didFinishRecordingTo:from:error:)`, so the returned `.mp4` path exists and is readable immediately.
- Reject `stopRecordVideo()` when AVFoundation reports a recording error, and propagate the same finalized URL and finish reason to both the promise result and the `recordingFinished` listener.
- Guard against stopping when no recording is active or when a stop is already pending.

## Test plan
- [x] `bun run verify:android`
- [x] `bun run verify:web`
- [ ] `bun run verify:ios` (blocked locally: iOS 26.4 SDK not installed in Xcode)
- [ ] On device/simulator: start camera with `enableVideoMode: true`, record, call `stopRecordVideo()`, then immediately `Filesystem.stat()` on the returned path — should succeed without polling
- [ ] Record twice in a row and confirm preview stays stable and both returned paths are valid
- [ ] Verify `recordingFinished` listener receives the same `videoFilePath` and `reason` as `stopRecordVideo()`

Fixes #376

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved video recording stop flow for more reliable results.
  * Added better validation when stopping a recording, including handling of invalid or duplicate stop requests.
  * Returned the actual stop reason and clearer error handling when recording ends.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->