### PR TITLE
fix(ios): stop videoStabilizationMode from freezing preview (fixes #377)

### DIFF
--- a/ios/Sources/CapgoCameraPreviewPlugin/CameraController.swift
+++ b/ios/Sources/CapgoCameraPreviewPlugin/CameraController.swift
@@ -156,7 +156,8 @@ class CameraController: NSObject {
     private var configuredVideoFrameRate: Int?
     var videoCodec: String = "avc1"
     var videoStabilizationMode: String = "off"
-    private var cachedSupportedVideoStabilizationModes: [String]?
+    private var cachedSupportedVideoStabilizationModes: [String] = []
+    private var isSupportedVideoStabilizationModesCacheValid = false
 
     private static let allVideoQualities = ["low", "medium", "high", "2160p", "1080p", "720p", "480p", "4:3"]
 
@@ -223,8 +224,8 @@ class CameraController: NSObject {
     }
 
     func getSupportedVideoStabilizationModes() -> [String] {
-        if let cached = self.cachedSupportedVideoStabilizationModes {
-            return cached
+        if self.isSupportedVideoStabilizationModesCacheValid {
+            return self.cachedSupportedVideoStabilizationModes
         }
         return self.refreshSupportedVideoStabilizationModesCache()
     }
@@ -246,10 +247,7 @@ class CameraController: NSObject {
         }
 
         if self.isVideoStabilizationOutputAttached() {
-            let supportedModes = self.getSupportedVideoStabilizationModes()
-            guard supportedModes.contains(mode) else {
-                throw CameraControllerError.invalidOperation
-            }
+            try self.validateVideoStabilizationMode(mode)
         }
 
         self.videoStabilizationMode = mode
@@ -265,29 +263,22 @@ class CameraController: NSObject {
 
     @discardableResult
     private func refreshSupportedVideoStabilizationModesCache() -> [String] {
-        guard let connection = self.fileVideoOutput?.connection(with: .video) else {
-            let modes = ["off"]
-            self.cachedSupportedVideoStabilizationModes = modes
-            return modes
-        }
-
-        guard connection.isVideoStabilizationSupported else {
-            let modes = ["off"]
-            self.cachedSupportedVideoStabilizationModes = modes
-            return modes
-        }
-
-        var modes: [String] = []
-        self.configureCaptureSession {
-            modes = self.probeSupportedVideoStabilizationModes(on: connection)
-        }
-
+        let modes = self.probeSupportedVideoStabilizationModes()
         self.cachedSupportedVideoStabilizationModes = modes
+        self.isSupportedVideoStabilizationModesCacheValid = true
         return modes
     }
 
     private func invalidateSupportedVideoStabilizationModesCache() {
-        self.cachedSupportedVideoStabilizationModes = nil
+        self.isSupportedVideoStabilizationModesCacheValid = false
+        self.cachedSupportedVideoStabilizationModes = []
+    }
+
+    private func validateVideoStabilizationMode(_ mode: String) throws {
+        let supportedModes = self.getSupportedVideoStabilizationModes()
+        guard supportedModes.contains(mode) else {
+            throw CameraControllerError.invalidOperation
+        }
     }
 
     private func isVideoStabilizationOutputAttached() -> Bool {
@@ -309,28 +300,40 @@ class CameraController: NSObject {
         block()
     }
 
-    private func probeSupportedVideoStabilizationModes(on connection: AVCaptureConnection) -> [String] {
-        guard connection.isVideoStabilizationSupported else {
+    private func activeVideoCaptureDevice() -> AVCaptureDevice? {
+        switch self.currentCameraPosition {
+        case .front:
+            return self.frontCamera
+        case .rear:
+            return self.rearCamera
+        default:
+            return nil
+        }
+    }
+
+    private func probeSupportedVideoStabilizationModes() -> [String] {
+        guard let connection = self.fileVideoOutput?.connection(with: .video),
+              connection.isVideoStabilizationSupported,
+              let device = self.activeVideoCaptureDevice() else {
             return ["off"]
         }
 
-        let savedPreferred = connection.preferredVideoStabilizationMode
-        var supported: [String] = []
+        let format = device.activeFormat
+        var supported: [String] = ["off"]
 
-        for candidate in Self.allVideoStabilizationModeCandidates() {
-            connection.preferredVideoStabilizationMode = candidate.mode
-            if connection.preferredVideoStabilizationMode == candidate.mode {
+        for candidate in Self.allVideoStabilizationModeCandidates() where candidate.mode != .off {
+            if format.isVideoStabilizationModeSupported(candidate.mode) {
                 supported.append(candidate.name)
             }
         }
 
-        connection.preferredVideoStabilizationMode = savedPreferred
-        return supported.isEmpty ? ["off"] : supported
+        return supported
     }
 
-    private func refreshVideoStabilizationAfterMovieOutputAttached() {
+    private func refreshVideoStabilizationAfterMovieOutputAttached() throws {
         self.invalidateSupportedVideoStabilizationModesCache()
-        self.refreshSupportedVideoStabilizationModesCache()
+        _ = self.refreshSupportedVideoStabilizationModesCache()
+        try self.validateVideoStabilizationMode(self.videoStabilizationMode)
         self.applyVideoStabilizationMode()
     }
 
@@ -718,7 +721,7 @@ extension CameraController {
                     captureSession.addOutput(fileVideoOutput)
                     // Set orientation immediately
                     self.setVideoOrientation(videoOrientation, on: fileVideoOutput.connections)
-                    self.refreshVideoStabilizationAfterMovieOutputAttached()
+                    try self.refreshVideoStabilizationAfterMovieOutputAttached()
                 }
 
                 // Set up preview layer session in the same configuration block
@@ -1299,7 +1302,7 @@ extension CameraController {
             captureSession.removeOutput(fileVideoOutput)
             if captureSession.canAddOutput(fileVideoOutput) {
                 captureSession.addOutput(fileVideoOutput)
-                self.refreshVideoStabilizationAfterMovieOutputAttached()
+                try self.refreshVideoStabilizationAfterMovieOutputAttached()
             }
         }
 
@@ -2441,6 +2444,16 @@ extension CameraController {
             captureSession.addInput(audioInput)
         }
 
+        // Re-attach movie file output so its connection is bound to the new input.
+        if let fileVideoOutput = self.fileVideoOutput,
+           captureSession.outputs.contains(where: { $0 === fileVideoOutput }) {
+            captureSession.removeOutput(fileVideoOutput)
+            if captureSession.canAddOutput(fileVideoOutput) {
+                captureSession.addOutput(fileVideoOutput)
+                try self.refreshVideoStabilizationAfterMovieOutputAttached()
+            }
+        }
+
         // Update video orientation
         self.updateVideoOrientation()
     }
@@ -2811,8 +2824,12 @@ extension CameraController {
             self.configureCaptureSession {
                 if captureSession.canAddOutput(fileVideoOutput) {
                     captureSession.addOutput(fileVideoOutput)
-                    self.refreshVideoStabilizationAfterMovieOutputAttached()
-                    didAddOutput = true
+                    do {
+                        try self.refreshVideoStabilizationAfterMovieOutputAttached()
+                        didAddOutput = true
+                    } catch {
+                        didAddOutput = false
+                    }
                 }
             }
             guard didAddOutput else {

--- a/ios/Sources/CapgoCameraPreviewPlugin/CameraController.swift
+++ b/ios/Sources/CapgoCameraPreviewPlugin/CameraController.swift
@@ -156,6 +156,7 @@ class CameraController: NSObject {
     private var configuredVideoFrameRate: Int?
     var videoCodec: String = "avc1"
     var videoStabilizationMode: String = "off"
+    private var cachedSupportedVideoStabilizationModes: [String]?
 
     private static let allVideoQualities = ["low", "medium", "high", "2160p", "1080p", "720p", "480p", "4:3"]
 
@@ -222,23 +223,10 @@ class CameraController: NSObject {
     }
 
     func getSupportedVideoStabilizationModes() -> [String] {
-        guard let connection = self.fileVideoOutput?.connection(with: .video),
-              connection.isVideoStabilizationSupported else {
-            return ["off"]
+        if let cached = self.cachedSupportedVideoStabilizationModes {
+            return cached
         }
-
-        let savedPreferred = connection.preferredVideoStabilizationMode
-        var supported: [String] = []
-
-        for candidate in Self.allVideoStabilizationModeCandidates() {
-            connection.preferredVideoStabilizationMode = candidate.mode
-            if connection.preferredVideoStabilizationMode == candidate.mode {
-                supported.append(candidate.name)
-            }
-        }
-
-        connection.preferredVideoStabilizationMode = savedPreferred
-        return supported.isEmpty ? ["off"] : supported
+        return self.refreshSupportedVideoStabilizationModesCache()
     }
 
     func getVideoStabilizationMode() -> String {
@@ -256,12 +244,94 @@ class CameraController: NSObject {
         guard let avMode = self.avVideoStabilizationMode(from: mode) else {
             throw CameraControllerError.invalidOperation
         }
-        let supportedModes = self.getSupportedVideoStabilizationModes()
-        guard supportedModes.contains(mode) else {
-            throw CameraControllerError.invalidOperation
+
+        if self.isVideoStabilizationOutputAttached() {
+            let supportedModes = self.getSupportedVideoStabilizationModes()
+            guard supportedModes.contains(mode) else {
+                throw CameraControllerError.invalidOperation
+            }
         }
+
         self.videoStabilizationMode = mode
-        self.applyVideoStabilizationMode(avMode)
+
+        guard self.isVideoStabilizationOutputAttached() else {
+            return
+        }
+
+        self.configureCaptureSession {
+            self.applyVideoStabilizationMode(avMode)
+        }
+    }
+
+    @discardableResult
+    private func refreshSupportedVideoStabilizationModesCache() -> [String] {
+        guard let connection = self.fileVideoOutput?.connection(with: .video) else {
+            let modes = ["off"]
+            self.cachedSupportedVideoStabilizationModes = modes
+            return modes
+        }
+
+        guard connection.isVideoStabilizationSupported else {
+            let modes = ["off"]
+            self.cachedSupportedVideoStabilizationModes = modes
+            return modes
+        }
+
+        var modes: [String] = []
+        self.configureCaptureSession {
+            modes = self.probeSupportedVideoStabilizationModes(on: connection)
+        }
+
+        self.cachedSupportedVideoStabilizationModes = modes
+        return modes
+    }
+
+    private func invalidateSupportedVideoStabilizationModesCache() {
+        self.cachedSupportedVideoStabilizationModes = nil
+    }
+
+    private func isVideoStabilizationOutputAttached() -> Bool {
+        guard let captureSession = self.captureSession,
+              let fileVideoOutput = self.fileVideoOutput else {
+            return false
+        }
+        return captureSession.outputs.contains(where: { $0 === fileVideoOutput })
+    }
+
+    private func configureCaptureSession(_ block: () -> Void) {
+        guard let captureSession = self.captureSession else {
+            block()
+            return
+        }
+
+        captureSession.beginConfiguration()
+        defer { captureSession.commitConfiguration() }
+        block()
+    }
+
+    private func probeSupportedVideoStabilizationModes(on connection: AVCaptureConnection) -> [String] {
+        guard connection.isVideoStabilizationSupported else {
+            return ["off"]
+        }
+
+        let savedPreferred = connection.preferredVideoStabilizationMode
+        var supported: [String] = []
+
+        for candidate in Self.allVideoStabilizationModeCandidates() {
+            connection.preferredVideoStabilizationMode = candidate.mode
+            if connection.preferredVideoStabilizationMode == candidate.mode {
+                supported.append(candidate.name)
+            }
+        }
+
+        connection.preferredVideoStabilizationMode = savedPreferred
+        return supported.isEmpty ? ["off"] : supported
+    }
+
+    private func refreshVideoStabilizationAfterMovieOutputAttached() {
+        self.invalidateSupportedVideoStabilizationModesCache()
+        self.refreshSupportedVideoStabilizationModesCache()
+        self.applyVideoStabilizationMode()
     }
 
     private static func allVideoStabilizationModeCandidates() -> [(name: String, mode: AVCaptureVideoStabilizationMode)] {
@@ -648,7 +718,7 @@ extension CameraController {
                     captureSession.addOutput(fileVideoOutput)
                     // Set orientation immediately
                     self.setVideoOrientation(videoOrientation, on: fileVideoOutput.connections)
-                    self.applyVideoStabilizationMode()
+                    self.refreshVideoStabilizationAfterMovieOutputAttached()
                 }
 
                 // Set up preview layer session in the same configuration block
@@ -1229,7 +1299,7 @@ extension CameraController {
             captureSession.removeOutput(fileVideoOutput)
             if captureSession.canAddOutput(fileVideoOutput) {
                 captureSession.addOutput(fileVideoOutput)
-                self.applyVideoStabilizationMode()
+                self.refreshVideoStabilizationAfterMovieOutputAttached()
             }
         }
 
@@ -2412,6 +2482,7 @@ extension CameraController {
 
         // Reset output preparation status
         self.outputsPrepared = false
+        self.invalidateSupportedVideoStabilizationModesCache()
 
         // Reset first frame detection
         self.hasReceivedFirstFrame = false
@@ -2736,15 +2807,17 @@ extension CameraController {
         // Ensure the movie file output is attached to the active session.
         // If the camera was started without cameraMode=true, the output may not have been added yet.
         if !captureSession.outputs.contains(where: { $0 === fileVideoOutput }) {
-            captureSession.beginConfiguration()
-            if captureSession.canAddOutput(fileVideoOutput) {
-                captureSession.addOutput(fileVideoOutput)
-                self.applyVideoStabilizationMode()
-            } else {
-                captureSession.commitConfiguration()
+            var didAddOutput = false
+            self.configureCaptureSession {
+                if captureSession.canAddOutput(fileVideoOutput) {
+                    captureSession.addOutput(fileVideoOutput)
+                    self.refreshVideoStabilizationAfterMovieOutputAttached()
+                    didAddOutput = true
+                }
+            }
+            guard didAddOutput else {
                 throw CameraControllerError.invalidOperation
             }
-            captureSession.commitConfiguration()
         }
 
         if let connection = fileVideoOutput.connection(with: .video) {
@@ -2781,7 +2854,9 @@ extension CameraController {
             fileVideoOutput.setOutputSettings([AVVideoCodecKey: codecType], for: connection)
         }
 
-        self.applyVideoStabilizationMode()
+        self.configureCaptureSession {
+            self.applyVideoStabilizationMode()
+        }
 
         // Start recording video
         fileVideoOutput.startRecording(to: fileUrl, recordingDelegate: self)

--- a/ios/Sources/CapgoCameraPreviewPlugin/Plugin.swift
+++ b/ios/Sources/CapgoCameraPreviewPlugin/Plugin.swift
@@ -779,16 +779,7 @@ public class CameraPreview: CAPPlugin, CAPBridgedPlugin, CLLocationManagerDelega
 
         // Default to high if not provided
         let videoQuality = call.getString("videoQuality") ?? "high"
-        if let videoStabilizationMode = call.getString("videoStabilizationMode") {
-            do {
-                try self.cameraController.setVideoStabilizationMode(videoStabilizationMode)
-            } catch {
-                self.pendingStartBarcodeScannerOptions = nil
-                self.isInitializing = false
-                call.reject("Failed to set video stabilization mode: \(error.localizedDescription)")
-                return
-            }
-        }
+        let videoStabilizationMode = call.getString("videoStabilizationMode")
         self.pendingStartBarcodeScannerOptions = self.barcodeScannerStartOptions(from: call)
 
         let initialZoomLevel = call.getFloat("initialZoomLevel")
@@ -810,6 +801,19 @@ public class CameraPreview: CAPPlugin, CAPBridgedPlugin, CLLocationManagerDelega
                     call.reject("camera already started")
                 }
                 return
+            }
+
+            if let videoStabilizationMode = videoStabilizationMode {
+                do {
+                    try self.cameraController.setVideoStabilizationMode(videoStabilizationMode)
+                } catch {
+                    DispatchQueue.main.async {
+                        self.isInitializing = false
+                        self.pendingStartBarcodeScannerOptions = nil
+                        call.reject("Failed to set video stabilization mode: \(error.localizedDescription)")
+                    }
+                    return
+                }
             }
 
             self.cameraController.prepare(cameraPosition: self.cameraPosition, deviceId: deviceId, disableAudio: self.disableAudio, cameraMode: cameraMode, aspectRatio: self.aspectRatio, aspectMode: self.aspectMode, initialZoomLevel: initialZoomLevel, disableFocusIndicator: self.disableFocusIndicator, videoQuality: videoQuality) { error in

--- a/ios/Sources/CapgoCameraPreviewPlugin/Plugin.swift
+++ b/ios/Sources/CapgoCameraPreviewPlugin/Plugin.swift
@@ -676,6 +676,7 @@ public class CameraPreview: CAPPlugin, CAPBridgedPlugin, CLLocationManagerDelega
         print("  - disableFocusIndicator: \(call.getBool("disableFocusIndicator") ?? false)")
         print("  - force: \(call.getBool("force") ?? false)")
         print("  - videoQuality: \(call.getString("videoQuality") ?? "high")")
+        print("  - videoStabilizationMode: \(call.getString("videoStabilizationMode") ?? "off")")
 
         let force = call.getBool("force") ?? false
 
@@ -778,6 +779,16 @@ public class CameraPreview: CAPPlugin, CAPBridgedPlugin, CLLocationManagerDelega
 
         // Default to high if not provided
         let videoQuality = call.getString("videoQuality") ?? "high"
+        if let videoStabilizationMode = call.getString("videoStabilizationMode") {
+            do {
+                try self.cameraController.setVideoStabilizationMode(videoStabilizationMode)
+            } catch {
+                self.pendingStartBarcodeScannerOptions = nil
+                self.isInitializing = false
+                call.reject("Failed to set video stabilization mode: \(error.localizedDescription)")
+                return
+            }
+        }
         self.pendingStartBarcodeScannerOptions = self.barcodeScannerStartOptions(from: call)
 
         let initialZoomLevel = call.getFloat("initialZoomLevel")


### PR DESCRIPTION
## Summary
- Cache supported video stabilization modes when the movie file output is attached, instead of probing by repeatedly mutating a live `AVCaptureConnection` on every `setVideoStabilizationMode()` / `getSupportedVideoStabilizationModes()` call.
- Run stabilization probing and mode application inside `AVCaptureSession` configuration blocks so the preview no longer flickers or freezes when starting a recording with `videoStabilizationMode`.
- Honor `videoStabilizationMode` in iOS `start()` to match the public TypeScript `CameraPreviewOptions` API.

## Test plan
- [ ] Start preview with `enableVideoMode: true`, then call `startRecordVideo({ videoStabilizationMode: 'auto' })` and confirm the preview stays stable (no flicker/freeze).
- [ ] Repeat recording start/stop cycles with and without `videoStabilizationMode`.
- [ ] Call `getSupportedVideoStabilizationModes()` and `isVideoStabilizationSupported()` while preview is running and confirm no visible flicker.
- [ ] Start preview with `videoStabilizationMode: 'auto'` in `start()` options and verify the mode is applied for subsequent recordings.
- [ ] Verify unsupported modes still reject cleanly via `setVideoStabilizationMode()` / `startRecordVideo()`.


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Camera startup now respects the requested video stabilization setting from the beginning of the session.
  * Stabilization options are now checked and reused more reliably when the camera is attached or switched.

* **Bug Fixes**
  * Improved camera stabilization handling to reduce failures when attaching video recording during capture.
  * If stabilization cannot be applied at startup, initialization now stops cleanly with an error instead of continuing in a broken state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->