### PR TITLE
fix(ios): preserve full video duration on stopRecordVideo (fixes #364)

### DIFF
--- a/ios/Sources/CapgoCameraPreviewPlugin/CameraController.swift
+++ b/ios/Sources/CapgoCameraPreviewPlugin/CameraController.swift
@@ -623,7 +623,10 @@ extension CameraController {
         self.photoOutput?.isHighResolutionCaptureEnabled = true
 
         // Create video output
-        self.fileVideoOutput = AVCaptureMovieFileOutput()
+        let movieFileOutput = AVCaptureMovieFileOutput()
+        // MP4 does not support movie fragments; the default 10s interval drops the final partial segment on stop.
+        movieFileOutput.movieFragmentInterval = .invalid
+        self.fileVideoOutput = movieFileOutput
 
         // Create data output for preview
         self.dataOutput = AVCaptureVideoDataOutput()


### PR DESCRIPTION
## Summary
- Disable `AVCaptureMovieFileOutput` movie fragments when creating the recorder output.
- iOS defaults to 10-second fragments, which are incompatible with `.mp4` output and causes the final partial segment to be dropped when `stopRecordVideo()` is called.

## Root cause
`AVCaptureMovieFileOutput.movieFragmentInterval` defaults to 10 seconds. Our recordings are saved as `.mp4`, and fragmented MP4 writing leaves only complete 10-second chunks usable when recording stops manually (e.g. 13s recording → 10s file, 24s → 20s).

## Test plan
- [x] `bun run verify`
- [ ] On iOS device: record for 13+ seconds, stop, confirm output duration matches wall-clock recording time
- [ ] On iOS device: record for 24+ seconds, stop, confirm output is not truncated to 20 seconds
- [ ] Confirm Android behavior unchanged

Fixes #364


Made with [Cursor](https://cursor.com)